### PR TITLE
feat: simplify queued benchmark orchestration to S3-only

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark-request.md
+++ b/.github/ISSUE_TEMPLATE/benchmark-request.md
@@ -1,6 +1,6 @@
 ---
 name: Benchmark request
-about: Request a new scfuzzbench benchmark run (3-step workflow).
+about: Request a new scfuzzbench benchmark run (4-step workflow).
 title: "benchmark: <org>/<repo>@<ref>"
 labels: "benchmark/01-pending"
 ---
@@ -14,7 +14,8 @@ Notes:
 - Step `01` (`benchmark/01-pending`) is applied by this template at issue creation.
 - Step `02` (`benchmark/02-validated`) is applied by the bot after JSON validation passes.
 - Step `03` (`benchmark/03-approved`) is applied manually by a maintainer to start the run.
-- Limits: `instances_per_fuzzer` must be in `[1, 20]`, `timeout_hours` must be in `[0.25, 72]`.
+- Step `04` (`benchmark/04-running`) is applied automatically by CI when the benchmark starts.
+- Limits: `instances_per_fuzzer` must be in `[1, 20]`, `max_parallel_instances` in `[0, 400]`, `timeout_hours` in `[0.25, 72]`.
 
 ```json
 {
@@ -23,6 +24,7 @@ Notes:
   "benchmark_type": "property",
   "instance_type": "c6a.4xlarge",
   "instances_per_fuzzer": 4,
+  "max_parallel_instances": 3,
   "timeout_hours": 1,
   "fuzzers": ["echidna", "medusa", "foundry"],
   "foundry_version": "",

--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -57,6 +57,21 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Checkout (tarball)
+        timeout-minutes: 5
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          url="https://codeload.github.com/${REPO}/tar.gz/${SHA}"
+          curl -fsSL "${url}" -o repo.tar.gz
+          topdir="$(tar -tzf repo.tar.gz | sed -n '1p' | cut -d/ -f1)"
+          tar -xzf repo.tar.gz
+          shopt -s dotglob
+          mv "${topdir}"/* .
+          rm -rf "${topdir}" repo.tar.gz
+
       - name: Discover runs
         id: discover
         env:
@@ -93,8 +108,13 @@ jobs:
           matrix=$(python3 - <<'PY'
           import json
           import os
+          from pathlib import Path
           import subprocess
+          import sys
           import time
+
+          sys.path.insert(0, str((Path.cwd() / "scripts").resolve()))
+          from run_completion import is_queue_mode_run, is_run_complete, timeout_hours_from_manifest
 
           bucket = os.environ["SCFUZZBENCH_BUCKET"]
           grace = int(os.environ.get("GRACE_SECONDS", "3600"))
@@ -137,15 +157,24 @@ jobs:
                       manifest = json.loads(manifest_raw)
                   except Exception:
                       continue
-                  try:
-                      timeout_hours = float(manifest.get("timeout_hours", 24))
-                  except Exception:
-                      timeout_hours = 24.0
-                  try:
-                      run_start = int(run_id)
-                  except ValueError:
-                      continue
-                  if now >= run_start + int(timeout_hours * 3600) + grace:
+                  timeout_hours = timeout_hours_from_manifest(manifest, default=24.0)
+                  queue_status = ""
+                  if is_queue_mode_run(manifest):
+                      status_key = f"runs/{run_id}/{benchmark_uuid}/status/run.json"
+                      try:
+                          status_raw = aws("s3", "cp", f"s3://{bucket}/{status_key}", "-")
+                          status = json.loads(status_raw)
+                          queue_status = status.get("status", "")
+                      except Exception:
+                          continue
+
+                  if is_run_complete(
+                      manifest,
+                      run_id=run_id,
+                      now_epoch=now,
+                      grace_seconds=grace,
+                      queue_status=queue_status,
+                  ):
                       runs.append(
                           {
                               "benchmark_uuid": benchmark_uuid,

--- a/.github/workflows/benchmark-request.yml
+++ b/.github/workflows/benchmark-request.yml
@@ -23,6 +23,7 @@ jobs:
       benchmark_type: ${{ steps.prepare.outputs.benchmark_type }}
       instance_type: ${{ steps.prepare.outputs.instance_type }}
       instances_per_fuzzer: ${{ steps.prepare.outputs.instances_per_fuzzer }}
+      max_parallel_instances: ${{ steps.prepare.outputs.max_parallel_instances }}
       timeout_hours: ${{ steps.prepare.outputs.timeout_hours }}
       fuzzers_json: ${{ steps.prepare.outputs.fuzzers_json }}
       foundry_version: ${{ steps.prepare.outputs.foundry_version }}
@@ -50,7 +51,8 @@ jobs:
             const LABEL_PENDING = "benchmark/01-pending";
             const LABEL_VALIDATED = "benchmark/02-validated";
             const LABEL_APPROVED = "benchmark/03-approved";
-            const STATUS_LABELS = [LABEL_PENDING, LABEL_VALIDATED, LABEL_APPROVED];
+            const LABEL_RUNNING = "benchmark/04-running";
+            const STATUS_LABELS = [LABEL_PENDING, LABEL_VALIDATED, LABEL_APPROVED, LABEL_RUNNING];
             const DEFAULT_FUZZERS = ["echidna", "medusa", "foundry"];
 
             function uniq(arr) {
@@ -197,6 +199,7 @@ jobs:
             await ensureLabel(LABEL_PENDING, "dff6dd", "Benchmark request created and pending JSON validation.");
             await ensureLabel(LABEL_VALIDATED, "b7eab2", "Benchmark request JSON validated by bot.");
             await ensureLabel(LABEL_APPROVED, "5ccf58", "Benchmark request approved by maintainer.");
+            await ensureLabel(LABEL_RUNNING, "1f7a1f", "Benchmark request accepted; benchmark run started.");
 
             const allowedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
             const authorAssociation = String(issue.author_association || "");
@@ -246,6 +249,9 @@ jobs:
 
             const inst = mustNumber(payload, "instances_per_fuzzer", { required: true, min: 1, max: 20, integer: true });
             if (!inst.ok) errors.push(inst.message);
+
+            const maxParallel = mustNumber(payload, "max_parallel_instances", { required: false, min: 0, max: 400, integer: true });
+            if (!maxParallel.ok) errors.push(maxParallel.message);
 
             const hours = mustNumber(payload, "timeout_hours", { required: true, min: 0.25, max: 72, integer: false });
             if (!hours.ok) errors.push(hours.message);
@@ -401,6 +407,7 @@ jobs:
                   `- Type: \`${bt}\``,
                   `- Instance type: \`${itype.value}\``,
                   `- Instances per fuzzer: \`${inst.value}\``,
+                  `- Max parallel workers: \`${maxParallel.ok && maxParallel.value !== null ? maxParallel.value : 0}\``,
                   `- Timeout hours: \`${hours.value}\``,
                   `- Fuzzers: \`${fuzzersJson}\``,
                   "",
@@ -425,6 +432,7 @@ jobs:
                   `- Type: \`${bt}\``,
                   `- Instance type: \`${itype.value}\``,
                   `- Instances per fuzzer: \`${inst.value}\``,
+                  `- Max parallel workers: \`${maxParallel.ok && maxParallel.value !== null ? maxParallel.value : 0}\``,
                   `- Timeout hours: \`${hours.value}\``,
                   `- Fuzzers: \`${fuzzersJson}\``,
                 ].join("\n")
@@ -437,6 +445,7 @@ jobs:
               core.setOutput("benchmark_type", bt);
               core.setOutput("instance_type", itype.value);
               core.setOutput("instances_per_fuzzer", String(inst.value));
+              core.setOutput("max_parallel_instances", String(maxParallel.ok && maxParallel.value !== null ? maxParallel.value : 0));
               core.setOutput("timeout_hours", String(hours.value));
               core.setOutput("fuzzers_json", fuzzersJson);
 
@@ -462,6 +471,7 @@ jobs:
       benchmark_type: ${{ needs.prepare.outputs.benchmark_type }}
       instance_type: ${{ needs.prepare.outputs.instance_type }}
       instances_per_fuzzer: ${{ fromJSON(needs.prepare.outputs.instances_per_fuzzer) }}
+      max_parallel_instances: ${{ fromJSON(needs.prepare.outputs.max_parallel_instances) }}
       timeout_hours: ${{ fromJSON(needs.prepare.outputs.timeout_hours) }}
       fuzzers_json: ${{ needs.prepare.outputs.fuzzers_json }}
       foundry_version: ${{ needs.prepare.outputs.foundry_version }}
@@ -494,7 +504,8 @@ jobs:
             const LABEL_PENDING = "benchmark/01-pending";
             const LABEL_VALIDATED = "benchmark/02-validated";
             const LABEL_APPROVED = "benchmark/03-approved";
-            const STATUS_LABELS = [LABEL_PENDING, LABEL_VALIDATED, LABEL_APPROVED];
+            const LABEL_RUNNING = "benchmark/04-running";
+            const STATUS_LABELS = [LABEL_PENDING, LABEL_VALIDATED, LABEL_APPROVED, LABEL_RUNNING];
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
             async function listIssueComments() {
@@ -557,12 +568,12 @@ jobs:
                 "- Run ID: `" + run_id + "`",
                 "- Benchmark UUID: `" + benchmark_uuid + "`",
                 "",
-                "Docs:",
-                `- ${docsUrl}`,
-                "",
-                "_Note: the docs site only shows **complete** runs (timeout + 1h grace)._",
-              ].join("\n")
-            );
+                  "Docs:",
+                  `- ${docsUrl}`,
+                  "",
+                  "_Note: the docs site only shows **complete** runs (queue-mode uses status/run.json terminal state; legacy runs use timeout + 1h grace)._",
+                ].join("\n")
+              );
 
-            await setStatusLabel(LABEL_APPROVED);
+            await setStatusLabel(LABEL_RUNNING);
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });

--- a/.github/workflows/benchmark-run.yml
+++ b/.github/workflows/benchmark-run.yml
@@ -26,6 +26,11 @@ on:
         required: true
         type: number
         default: 10
+      max_parallel_instances:
+        description: "Maximum concurrent workers (0 means all requested shards)."
+        required: false
+        type: number
+        default: 0
       timeout_hours:
         description: "Timeout per fuzzer run (hours)."
         required: true
@@ -96,6 +101,11 @@ on:
         required: false
         type: number
         default: 10
+      max_parallel_instances:
+        description: "Maximum concurrent workers (0 means all requested shards)."
+        required: false
+        type: number
+        default: 0
       timeout_hours:
         description: "Timeout per fuzzer run (hours)."
         required: false
@@ -173,6 +183,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: benchmark-run-global-dispatch
+  cancel-in-progress: false
+
 jobs:
   benchmark-run:
     runs-on: ubuntu-latest
@@ -182,6 +196,14 @@ jobs:
     env:
       AWS_REGION: ${{ secrets.AWS_REGION != '' && secrets.AWS_REGION || 'us-east-1' }}
       SCFUZZBENCH_BUCKET: ${{ secrets.SCFUZZBENCH_BUCKET }}
+      SCFUZZBENCH_LOCK_NAME: benchmark-global-lock
+      SCFUZZBENCH_LOCK_LEASE_SECONDS: "7200"
+      SCFUZZBENCH_LOCK_ACQUIRE_TIMEOUT_SECONDS: "0"
+      SCFUZZBENCH_LOCK_ACQUIRE_MAX_BACKOFF_SECONDS: "120"
+      SCFUZZBENCH_LOCK_RENEW_HEARTBEAT_SECONDS: "60"
+      TF_APPLY_MAX_ATTEMPTS: "6"
+      TF_APPLY_BASE_BACKOFF_SECONDS: "30"
+      TF_APPLY_MAX_BACKOFF_SECONDS: "300"
     steps:
       - name: Checkout (tarball)
         timeout-minutes: 5
@@ -251,6 +273,7 @@ jobs:
           BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INSTANCE_TYPE: ${{ inputs.instance_type }}
           INSTANCES_PER_FUZZER: ${{ inputs.instances_per_fuzzer }}
+          MAX_PARALLEL_INSTANCES: ${{ inputs.max_parallel_instances }}
           TIMEOUT_HOURS: ${{ inputs.timeout_hours }}
           FUZZERS_JSON: ${{ inputs.fuzzers_json }}
           FOUNDRY_VERSION: ${{ inputs.foundry_version }}
@@ -349,6 +372,13 @@ jobs:
             fail "instances_per_fuzzer must be an integer in [1, 20]"
           fi
 
+          if [[ ! "${MAX_PARALLEL_INSTANCES}" =~ ^[0-9]+$ ]]; then
+            fail "max_parallel_instances must be an integer >= 0"
+          fi
+          if (( MAX_PARALLEL_INSTANCES > 400 )); then
+            fail "max_parallel_instances must be <= 400"
+          fi
+
           if [[ ! "${TIMEOUT_HOURS}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
             fail "timeout_hours must be a number"
           fi
@@ -428,6 +458,66 @@ jobs:
           PY
           fi
 
+      - name: Plan shard execution
+        id: shard_plan
+        env:
+          INSTANCES_PER_FUZZER: ${{ inputs.instances_per_fuzzer }}
+          FUZZERS_JSON: ${{ inputs.fuzzers_json }}
+          MAX_PARALLEL_INSTANCES: ${{ inputs.max_parallel_instances }}
+        run: |
+          set -euo pipefail
+          run_id="$(date +%s)"
+          fuzzers="${FUZZERS_JSON:-}"
+          if [[ -z "${fuzzers}" ]]; then
+            fuzzers='["echidna","medusa","foundry"]'
+          fi
+          fuzzer_count="$(FUZZERS_JSON="${fuzzers}" python3 - <<'PY'
+          import json
+          import os
+          obj = json.loads(os.environ["FUZZERS_JSON"])
+          print(len(obj))
+          PY
+          )"
+          requested_shards="$((INSTANCES_PER_FUZZER * fuzzer_count))"
+          effective_parallel="$(REQUESTED_SHARDS="${requested_shards}" MAX_PARALLEL_INSTANCES="${MAX_PARALLEL_INSTANCES}" python3 - <<'PY'
+          import os
+
+          requested = int(os.environ["REQUESTED_SHARDS"])
+          requested_max = int(os.environ["MAX_PARALLEL_INSTANCES"])
+          effective = requested if requested_max <= 0 else min(requested, requested_max)
+
+          if effective < 1:
+              effective = 1
+          print(effective)
+          PY
+          )"
+
+          {
+            echo "run_id=${run_id}"
+            echo "fuzzers_json=${fuzzers}"
+            echo "requested_shards=${requested_shards}"
+            echo "effective_parallel=${effective_parallel}"
+            echo "max_parallel_requested=${MAX_PARALLEL_INSTANCES}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Acquire global run lock
+        id: lock
+        env:
+          RUN_ID: ${{ steps.shard_plan.outputs.run_id }}
+          LOCK_LEASE_SECONDS: ${{ env.SCFUZZBENCH_LOCK_LEASE_SECONDS }}
+          LOCK_WAIT_TIMEOUT_SECONDS: ${{ env.SCFUZZBENCH_LOCK_ACQUIRE_TIMEOUT_SECONDS }}
+          LOCK_MAX_BACKOFF_SECONDS: ${{ env.SCFUZZBENCH_LOCK_ACQUIRE_MAX_BACKOFF_SECONDS }}
+        run: |
+          set -euo pipefail
+          python3 scripts/benchmark_lock.py acquire \
+            --bucket "${SCFUZZBENCH_BUCKET}" \
+            --lock-name "${SCFUZZBENCH_LOCK_NAME}" \
+            --owner-run-id "${RUN_ID}" \
+            --workflow-run-id "${GITHUB_RUN_ID}" \
+            --lease-seconds "${LOCK_LEASE_SECONDS}" \
+            --wait-timeout-seconds "${LOCK_WAIT_TIMEOUT_SECONDS}" \
+            --max-backoff-seconds "${LOCK_MAX_BACKOFF_SECONDS}"
+
       - name: Terraform apply
         id: apply
         env:
@@ -437,7 +527,9 @@ jobs:
           INSTANCE_TYPE: ${{ inputs.instance_type }}
           INSTANCES_PER_FUZZER: ${{ inputs.instances_per_fuzzer }}
           TIMEOUT_HOURS: ${{ inputs.timeout_hours }}
-          FUZZERS_JSON: ${{ inputs.fuzzers_json }}
+          FUZZERS_JSON: ${{ steps.shard_plan.outputs.fuzzers_json }}
+          MAX_PARALLEL_EFFECTIVE: ${{ steps.shard_plan.outputs.effective_parallel }}
+          RUN_ID: ${{ steps.shard_plan.outputs.run_id }}
           FOUNDRY_VERSION: ${{ inputs.foundry_version }}
           FOUNDRY_GIT_REPO: ${{ inputs.foundry_git_repo }}
           FOUNDRY_GIT_REF: ${{ inputs.foundry_git_ref }}
@@ -447,14 +539,48 @@ jobs:
           GIT_TOKEN_SSM_PARAMETER_NAME: ${{ inputs.git_token_ssm_parameter_name }}
           FUZZER_ENV_JSON: ${{ inputs.fuzzer_env_json }}
           PROPERTIES_PATH: ${{ inputs.properties_path }}
+          LOCK_LEASE_SECONDS: ${{ steps.lock.outputs.lock_lease_seconds || env.SCFUZZBENCH_LOCK_LEASE_SECONDS }}
+          LOCK_HEARTBEAT_SECONDS: "120"
+          TF_APPLY_MAX_ATTEMPTS: ${{ env.TF_APPLY_MAX_ATTEMPTS }}
+          TF_APPLY_BASE_BACKOFF_SECONDS: ${{ env.TF_APPLY_BASE_BACKOFF_SECONDS }}
+          TF_APPLY_MAX_BACKOFF_SECONDS: ${{ env.TF_APPLY_MAX_BACKOFF_SECONDS }}
+          LOCK_RENEW_HEARTBEAT_SECONDS: ${{ env.SCFUZZBENCH_LOCK_RENEW_HEARTBEAT_SECONDS }}
         run: |
           set -euo pipefail
-          run_id=$(date +%s)
           fuzzers="${FUZZERS_JSON:-}"
           if [[ -z "${fuzzers}" ]]; then
             fuzzers='["echidna","medusa","foundry"]'
           fi
-          tf_args=(
+          if ! [[ "${MAX_PARALLEL_EFFECTIVE}" =~ ^[0-9]+$ ]] || (( MAX_PARALLEL_EFFECTIVE < 1 )); then
+            echo "Invalid MAX_PARALLEL_EFFECTIVE: ${MAX_PARALLEL_EFFECTIVE}" >&2
+            exit 1
+          fi
+          if ! [[ "${LOCK_LEASE_SECONDS}" =~ ^[0-9]+$ ]] || (( LOCK_LEASE_SECONDS < 300 )); then
+            echo "Invalid LOCK_LEASE_SECONDS: ${LOCK_LEASE_SECONDS}" >&2
+            exit 1
+          fi
+          if ! [[ "${LOCK_HEARTBEAT_SECONDS}" =~ ^[0-9]+$ ]] || (( LOCK_HEARTBEAT_SECONDS < 30 )); then
+            echo "Invalid LOCK_HEARTBEAT_SECONDS: ${LOCK_HEARTBEAT_SECONDS}" >&2
+            exit 1
+          fi
+          if ! [[ "${LOCK_RENEW_HEARTBEAT_SECONDS}" =~ ^[0-9]+$ ]] || (( LOCK_RENEW_HEARTBEAT_SECONDS < 10 )); then
+            echo "Invalid LOCK_RENEW_HEARTBEAT_SECONDS: ${LOCK_RENEW_HEARTBEAT_SECONDS}" >&2
+            exit 1
+          fi
+          if ! [[ "${TF_APPLY_MAX_ATTEMPTS}" =~ ^[0-9]+$ ]] || (( TF_APPLY_MAX_ATTEMPTS < 1 )); then
+            echo "Invalid TF_APPLY_MAX_ATTEMPTS: ${TF_APPLY_MAX_ATTEMPTS}" >&2
+            exit 1
+          fi
+          if ! [[ "${TF_APPLY_BASE_BACKOFF_SECONDS}" =~ ^[0-9]+$ ]] || (( TF_APPLY_BASE_BACKOFF_SECONDS < 1 )); then
+            echo "Invalid TF_APPLY_BASE_BACKOFF_SECONDS: ${TF_APPLY_BASE_BACKOFF_SECONDS}" >&2
+            exit 1
+          fi
+          if ! [[ "${TF_APPLY_MAX_BACKOFF_SECONDS}" =~ ^[0-9]+$ ]] || (( TF_APPLY_MAX_BACKOFF_SECONDS < TF_APPLY_BASE_BACKOFF_SECONDS )); then
+            echo "Invalid TF_APPLY_MAX_BACKOFF_SECONDS: ${TF_APPLY_MAX_BACKOFF_SECONDS}" >&2
+            exit 1
+          fi
+
+          tf_common_args=(
             -var "aws_region=${AWS_REGION}"
             -var "existing_bucket_name=${SCFUZZBENCH_BUCKET}"
             -var "target_repo_url=${TARGET_REPO_URL}"
@@ -464,30 +590,33 @@ jobs:
             -var "instances_per_fuzzer=${INSTANCES_PER_FUZZER}"
             -var "timeout_hours=${TIMEOUT_HOURS}"
             -var "fuzzers=${fuzzers}"
-            -var "run_id=${run_id}"
+            -var "run_id=${RUN_ID}"
             -var "scfuzzbench_commit=${GITHUB_SHA}"
+            -var "control_lock_name=${SCFUZZBENCH_LOCK_NAME}"
+            -var "control_lock_lease_seconds=${LOCK_LEASE_SECONDS}"
+            -var "control_lock_heartbeat_seconds=${LOCK_HEARTBEAT_SECONDS}"
           )
 
           if [[ -n "${FOUNDRY_VERSION}" ]]; then
-            tf_args+=(-var "foundry_version=${FOUNDRY_VERSION}")
+            tf_common_args+=(-var "foundry_version=${FOUNDRY_VERSION}")
           fi
           if [[ -n "${FOUNDRY_GIT_REPO}" ]]; then
-            tf_args+=(-var "foundry_git_repo=${FOUNDRY_GIT_REPO}")
+            tf_common_args+=(-var "foundry_git_repo=${FOUNDRY_GIT_REPO}")
           fi
           if [[ -n "${FOUNDRY_GIT_REF}" ]]; then
-            tf_args+=(-var "foundry_git_ref=${FOUNDRY_GIT_REF}")
+            tf_common_args+=(-var "foundry_git_ref=${FOUNDRY_GIT_REF}")
           fi
           if [[ -n "${ECHIDNA_VERSION}" ]]; then
-            tf_args+=(-var "echidna_version=${ECHIDNA_VERSION}")
+            tf_common_args+=(-var "echidna_version=${ECHIDNA_VERSION}")
           fi
           if [[ -n "${MEDUSA_VERSION}" ]]; then
-            tf_args+=(-var "medusa_version=${MEDUSA_VERSION}")
+            tf_common_args+=(-var "medusa_version=${MEDUSA_VERSION}")
           fi
           if [[ -n "${BITWUZLA_VERSION}" ]]; then
-            tf_args+=(-var "bitwuzla_version=${BITWUZLA_VERSION}")
+            tf_common_args+=(-var "bitwuzla_version=${BITWUZLA_VERSION}")
           fi
           if [[ -n "${GIT_TOKEN_SSM_PARAMETER_NAME}" ]]; then
-            tf_args+=(-var "git_token_ssm_parameter_name=${GIT_TOKEN_SSM_PARAMETER_NAME}")
+            tf_common_args+=(-var "git_token_ssm_parameter_name=${GIT_TOKEN_SSM_PARAMETER_NAME}")
           fi
 
           if [[ -n "${FUZZER_ENV_JSON}" || -n "${PROPERTIES_PATH}" ]]; then
@@ -505,11 +634,76 @@ jobs:
           print(json.dumps(data))
           PY
             )
-            tf_args+=(-var "fuzzer_env=${merged}")
+            tf_common_args+=(-var "fuzzer_env=${merged}")
           fi
 
-          terraform -chdir=infrastructure apply -auto-approve "${tf_args[@]}"
-          echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
+          current_parallel="${MAX_PARALLEL_EFFECTIVE}"
+          apply_attempt=1
+          while true; do
+            tf_args=("${tf_common_args[@]}" -var "max_parallel_instances=${current_parallel}")
+            echo "Terraform apply attempt ${apply_attempt}/${TF_APPLY_MAX_ATTEMPTS} with max_parallel_instances=${current_parallel}"
+            set +e
+            (
+              terraform -chdir=infrastructure apply -auto-approve "${tf_args[@]}" 2>&1 | tee terraform-apply.log
+            ) &
+            apply_pid=$!
+            renew_failed=0
+            while kill -0 "${apply_pid}" >/dev/null 2>&1; do
+              sleep "${LOCK_RENEW_HEARTBEAT_SECONDS}" || true
+              if ! kill -0 "${apply_pid}" >/dev/null 2>&1; then
+                break
+              fi
+              if ! python3 scripts/benchmark_lock.py renew \
+                --bucket "${SCFUZZBENCH_BUCKET}" \
+                --lock-name "${SCFUZZBENCH_LOCK_NAME}" \
+                --owner-run-id "${RUN_ID}" \
+                --lease-seconds "${LOCK_LEASE_SECONDS}"; then
+                renew_failed=1
+                kill "${apply_pid}" >/dev/null 2>&1 || true
+                break
+              fi
+            done
+            wait "${apply_pid}"
+            rc=$?
+            set -e
+            if (( renew_failed != 0 )); then
+              echo "Failed to renew global lock during terraform apply; aborting bootstrap." >&2
+              exit 1
+            fi
+
+            if (( rc == 0 )); then
+              {
+                echo "applied_parallel=${current_parallel}"
+                echo "apply_attempts=${apply_attempt}"
+              } >> "${GITHUB_OUTPUT}"
+              break
+            fi
+
+            if (( apply_attempt >= TF_APPLY_MAX_ATTEMPTS )); then
+              echo "Terraform apply failed after ${apply_attempt} attempt(s)." >&2
+              exit "${rc}"
+            fi
+
+            if ! grep -Eiq "(InsufficientInstanceCapacity|VcpuLimitExceeded|RequestLimitExceeded|ServiceUnavailable|Unavailable|InternalError|InsufficientFreeAddressesInSubnet|capacity)" terraform-apply.log; then
+              echo "Terraform apply failed with a non-retryable error." >&2
+              exit "${rc}"
+            fi
+
+            exponent=$((apply_attempt - 1))
+            raw_delay=$((TF_APPLY_BASE_BACKOFF_SECONDS * (2 ** exponent)))
+            if (( raw_delay > TF_APPLY_MAX_BACKOFF_SECONDS )); then
+              raw_delay=${TF_APPLY_MAX_BACKOFF_SECONDS}
+            fi
+            jitter=$((RANDOM % (TF_APPLY_BASE_BACKOFF_SECONDS + 1)))
+            delay=$((raw_delay + jitter))
+            if (( delay > TF_APPLY_MAX_BACKOFF_SECONDS )); then
+              delay=${TF_APPLY_MAX_BACKOFF_SECONDS}
+            fi
+
+            echo "Capacity/transient apply failure detected. Retrying in ${delay}s with max_parallel_instances=${current_parallel}."
+            apply_attempt=$((apply_attempt + 1))
+            sleep "${delay}"
+          done
 
       - name: Collect Terraform outputs
         id: tf_outputs
@@ -522,6 +716,35 @@ jobs:
             echo "benchmark_uuid=${benchmark_uuid}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Initialize S3 queue state
+        id: init_queue
+        run: |
+          set -euo pipefail
+          jq -c '.shards.value' run_metadata.json > shards.json
+          python3 scripts/queue_init_run.py \
+            --bucket "${SCFUZZBENCH_BUCKET}" \
+            --run-id "$(jq -r '.run_id.value' run_metadata.json)" \
+            --benchmark-uuid "$(jq -r '.benchmark_uuid.value' run_metadata.json)" \
+            --max-parallel-effective "$(jq -r '.max_parallel_effective.value' run_metadata.json)" \
+            --shards-json shards.json \
+            --summary-path queue-init-summary.json
+
+      - name: Mark lock handoff
+        id: lock_handoff
+        if: ${{ steps.init_queue.outcome == 'success' }}
+        run: echo "handoff=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Release global lock on bootstrap failure
+        if: ${{ failure() && steps.lock.outputs.lock_acquired == 'true' && steps.lock_handoff.outputs.handoff != 'true' }}
+        env:
+          RUN_ID: ${{ steps.shard_plan.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          python3 scripts/benchmark_lock.py release \
+            --bucket "${SCFUZZBENCH_BUCKET}" \
+            --lock-name "${SCFUZZBENCH_LOCK_NAME}" \
+            --owner-run-id "${RUN_ID}"
+
       - name: Upload run metadata
         uses: actions/upload-artifact@v4
         with:
@@ -530,9 +753,18 @@ jobs:
 
       - name: Summary
         run: |
+          applied_parallel="${{ steps.apply.outputs.applied_parallel }}"
+          if [[ -z "${applied_parallel}" ]]; then
+            applied_parallel="${{ steps.shard_plan.outputs.effective_parallel }}"
+          fi
           {
             echo "Benchmark run started."
             echo ""
             echo "- Run ID: ${{ steps.tf_outputs.outputs.run_id }}"
             echo "- Benchmark UUID: ${{ steps.tf_outputs.outputs.benchmark_uuid }}"
+            echo "- Requested shards: ${{ steps.shard_plan.outputs.requested_shards }}"
+            echo "- Max parallel workers (applied): ${applied_parallel}"
+            echo "- Terraform apply attempts: ${{ steps.apply.outputs.apply_attempts }}"
+            echo "- Global lock acquisition attempts: ${{ steps.lock.outputs.lock_attempts }}"
+            echo "- Global lock object: ${{ steps.lock.outputs.lock_object_key }}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/.vitepress/components/StartBenchmark.vue
+++ b/docs/.vitepress/components/StartBenchmark.vue
@@ -25,6 +25,7 @@ const targetCommit = ref("v0.5.6-recon");
 const benchmarkType = ref<BenchmarkType>("property");
 const instanceType = ref("c6a.4xlarge");
 const instancesPerFuzzer = ref(4);
+const maxParallelInstances = ref(0);
 const timeoutHours = ref(1);
 
 // Dynamically discover fuzzers from committed run scripts.
@@ -153,6 +154,7 @@ const requestJson = computed(() => {
     benchmark_type: benchmarkType.value,
     instance_type: instanceType.value.trim(),
     instances_per_fuzzer: instancesPerFuzzer.value,
+    max_parallel_instances: maxParallelInstances.value,
     timeout_hours: timeoutHours.value,
     fuzzers: participatingFuzzerKeys.value,
 
@@ -245,6 +247,18 @@ const showAdvanced = ref(false);
             type="number"
             min="1"
             max="20"
+            step="1"
+          />
+        </label>
+
+        <label class="sb-start__field">
+          <div class="sb-start__label">Max parallel workers (0 to use all shards)</div>
+          <input
+            v-model.number="maxParallelInstances"
+            class="sb-start__input"
+            type="number"
+            min="0"
+            max="400"
             step="1"
           />
         </label>

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ features:
   - title: Timestamp-first runs
     details: Run IDs are Unix timestamps, so “latest” is always obvious just by listing prefixes.
   - title: Complete runs only
-    details: The site lists only complete runs (timeout plus a 1h grace period) to avoid partial results.
+    details: The site lists only complete runs (queue status for queue-mode runs, timeout+grace for legacy runs).
   - title: Triage-friendly
     details: Complete runs missing analysis stay visible with warnings and raw-artifact links.
 ---

--- a/docs/runs/index.md
+++ b/docs/runs/index.md
@@ -3,7 +3,7 @@
 This page is generated in CI from the S3 run index (`runs/<run_id>/<benchmark_uuid>/manifest.json`).
 
 ::: tip
-Only **complete** runs are shown (timeout + 1h grace).
+Only **complete** runs are shown (queue status for queue-mode runs, timeout + 1h grace for legacy runs).
 
 If you are previewing locally, run the generator first:
 

--- a/docs/start.md
+++ b/docs/start.md
@@ -7,6 +7,7 @@ The request moves through GitHub labels:
 - `benchmark/01-pending`: added by the issue template on creation.
 - `benchmark/02-validated`: added by the bot after JSON validation passes.
 - `benchmark/03-approved`: added manually by a maintainer.
+- `benchmark/04-running`: added automatically by CI when the benchmark starts.
 
 <StartBenchmark />
 

--- a/fuzzers/_shared/common.sh
+++ b/fuzzers/_shared/common.sh
@@ -11,6 +11,8 @@ SCFUZZBENCH_BENCHMARK_MANIFEST_B64=${SCFUZZBENCH_BENCHMARK_MANIFEST_B64:-}
 SCFUZZBENCH_PROPERTIES_PATH=${SCFUZZBENCH_PROPERTIES_PATH:-}
 SCFUZZBENCH_RUNNER_METRICS=${SCFUZZBENCH_RUNNER_METRICS:-1}
 SCFUZZBENCH_RUNNER_METRICS_INTERVAL_SECONDS=${SCFUZZBENCH_RUNNER_METRICS_INTERVAL_SECONDS:-5}
+SCFUZZBENCH_QUEUE_MODE=${SCFUZZBENCH_QUEUE_MODE:-0}
+SCFUZZBENCH_ARTIFACT_SUFFIX=${SCFUZZBENCH_ARTIFACT_SUFFIX:-}
 
 SCFUZZBENCH_AWS_CREDS_ENV_FILE=${SCFUZZBENCH_AWS_CREDS_ENV_FILE:-${SCFUZZBENCH_ROOT}/aws_creds.env}
 SCFUZZBENCH_AWS_CREDS_REFRESH_SECONDS=${SCFUZZBENCH_AWS_CREDS_REFRESH_SECONDS:-300}
@@ -18,6 +20,18 @@ SCFUZZBENCH_AWS_CREDS_REFRESH_SECONDS=${SCFUZZBENCH_AWS_CREDS_REFRESH_SECONDS:-3
 log() {
   # Use stderr so command substitutions can safely capture stdout.
   echo "[$(date -Is)] $*" >&2
+}
+
+is_truthy() {
+  local flag="${1:-}"
+  case "${flag}" in
+    1|true|TRUE|yes|YES|on|ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 retry_cmd() {
@@ -296,6 +310,10 @@ finalize_run() {
     else
       log "Skipping upload in finalize; missing S3 bucket, run id, or fuzzer label."
     fi
+  fi
+  if is_truthy "${SCFUZZBENCH_QUEUE_MODE:-0}"; then
+    log "Queue mode enabled; skipping instance shutdown in finalize."
+    return ${exit_code}
   fi
   shutdown_instance
   return ${exit_code}
@@ -816,6 +834,15 @@ upload_results() {
   cache_instance_id || true
   local instance_id="${SCFUZZBENCH_INSTANCE_ID:-unknown}"
   local base_name="${instance_id}-${SCFUZZBENCH_FUZZER_LABEL}"
+  if [[ -n "${SCFUZZBENCH_ARTIFACT_SUFFIX:-}" ]]; then
+    local safe_suffix
+    safe_suffix=$(echo "${SCFUZZBENCH_ARTIFACT_SUFFIX}" | tr -cs 'A-Za-z0-9._-' '-')
+    safe_suffix="${safe_suffix#-}"
+    safe_suffix="${safe_suffix%-}"
+    if [[ -n "${safe_suffix}" ]]; then
+      base_name="${base_name}-${safe_suffix}"
+    fi
+  fi
   local upload_dir="${SCFUZZBENCH_ROOT}/upload"
   mkdir -p "${upload_dir}"
   local log_zip="${upload_dir}/logs-${base_name}.zip"

--- a/fuzzers/_shared/queue_worker.sh
+++ b/fuzzers/_shared/queue_worker.sh
@@ -1,0 +1,1122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /opt/scfuzzbench/common.sh
+
+require_env \
+  SCFUZZBENCH_RUN_ID \
+  SCFUZZBENCH_BENCHMARK_UUID \
+  SCFUZZBENCH_S3_BUCKET \
+  SCFUZZBENCH_LOCK_NAME \
+  SCFUZZBENCH_LOCK_OBJECT_KEY
+
+SCFUZZBENCH_QUEUE_IDLE_POLLS=${SCFUZZBENCH_QUEUE_IDLE_POLLS:-3}
+SCFUZZBENCH_QUEUE_EMPTY_SLEEP_SECONDS=${SCFUZZBENCH_QUEUE_EMPTY_SLEEP_SECONDS:-10}
+SCFUZZBENCH_QUEUE_BOOTSTRAP_WAIT_SECONDS=${SCFUZZBENCH_QUEUE_BOOTSTRAP_WAIT_SECONDS:-1800}
+SCFUZZBENCH_SHARD_MAX_ATTEMPTS=${SCFUZZBENCH_SHARD_MAX_ATTEMPTS:-5}
+SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS=${SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS:-30}
+SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS=${SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS:-300}
+SCFUZZBENCH_RUNNING_STALE_SECONDS=${SCFUZZBENCH_RUNNING_STALE_SECONDS:-900}
+SCFUZZBENCH_SHARD_HEARTBEAT_SECONDS=${SCFUZZBENCH_SHARD_HEARTBEAT_SECONDS:-60}
+SCFUZZBENCH_CLAIM_SETTLE_SECONDS=${SCFUZZBENCH_CLAIM_SETTLE_SECONDS:-2}
+SCFUZZBENCH_CLAIM_STALE_SECONDS=${SCFUZZBENCH_CLAIM_STALE_SECONDS:-1200}
+SCFUZZBENCH_LOCK_LEASE_SECONDS=${SCFUZZBENCH_LOCK_LEASE_SECONDS:-7200}
+SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS=${SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS:-120}
+SCFUZZBENCH_LOCK_HEARTBEAT_MAX_FAILURES=${SCFUZZBENCH_LOCK_HEARTBEAT_MAX_FAILURES:-3}
+
+for var_name in \
+  SCFUZZBENCH_QUEUE_IDLE_POLLS \
+  SCFUZZBENCH_QUEUE_EMPTY_SLEEP_SECONDS \
+  SCFUZZBENCH_QUEUE_BOOTSTRAP_WAIT_SECONDS \
+  SCFUZZBENCH_SHARD_MAX_ATTEMPTS \
+  SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS \
+  SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS \
+  SCFUZZBENCH_RUNNING_STALE_SECONDS \
+  SCFUZZBENCH_SHARD_HEARTBEAT_SECONDS \
+  SCFUZZBENCH_CLAIM_SETTLE_SECONDS \
+  SCFUZZBENCH_CLAIM_STALE_SECONDS \
+  SCFUZZBENCH_LOCK_LEASE_SECONDS \
+  SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS \
+  SCFUZZBENCH_LOCK_HEARTBEAT_MAX_FAILURES; do
+  value=${!var_name:-}
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    log "Invalid ${var_name}='${value}'"
+    exit 1
+  fi
+done
+
+if (( SCFUZZBENCH_QUEUE_IDLE_POLLS < 1 )); then
+  SCFUZZBENCH_QUEUE_IDLE_POLLS=1
+fi
+if (( SCFUZZBENCH_SHARD_MAX_ATTEMPTS < 1 )); then
+  SCFUZZBENCH_SHARD_MAX_ATTEMPTS=1
+fi
+if (( SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS < 1 )); then
+  SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS=1
+fi
+if (( SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS < SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS )); then
+  SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS=${SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS}
+fi
+if (( SCFUZZBENCH_SHARD_HEARTBEAT_SECONDS < 10 )); then
+  SCFUZZBENCH_SHARD_HEARTBEAT_SECONDS=10
+fi
+if (( SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS < 10 )); then
+  SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS=10
+fi
+if (( SCFUZZBENCH_LOCK_HEARTBEAT_MAX_FAILURES < 1 )); then
+  SCFUZZBENCH_LOCK_HEARTBEAT_MAX_FAILURES=1
+fi
+
+RUN_PREFIX="runs/${SCFUZZBENCH_RUN_ID}/${SCFUZZBENCH_BENCHMARK_UUID}"
+SHARD_PREFIX="${RUN_PREFIX}/queue/shards"
+CLAIM_PREFIX="${RUN_PREFIX}/queue/claims"
+STATUS_PREFIX="${RUN_PREFIX}/status"
+EVENT_PREFIX="${STATUS_PREFIX}/events"
+DLQ_PREFIX="${RUN_PREFIX}/dlq"
+RUN_STATUS_KEY="${STATUS_PREFIX}/run.json"
+LOCK_FAILURE_MARKER="${SCFUZZBENCH_ROOT}/lock-heartbeat.failed"
+INSTANCE_ID_SAFE="unknown"
+
+prepare_workspace
+cache_instance_id || true
+INSTANCE_ID_SAFE=$(echo "${SCFUZZBENCH_INSTANCE_ID:-unknown}" | tr -cs 'A-Za-z0-9._-' '-')
+INSTANCE_ID_SAFE=${INSTANCE_ID_SAFE#-}
+INSTANCE_ID_SAFE=${INSTANCE_ID_SAFE%-}
+if [[ -z "${INSTANCE_ID_SAFE}" ]]; then
+  INSTANCE_ID_SAFE="unknown"
+fi
+
+# Queue workers need aws + jq before they can poll/claim shards.
+install_base_packages
+
+iso_now() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+epoch_now() {
+  date +%s
+}
+
+epoch_ms_now() {
+  date +%s%3N
+}
+
+safe_token() {
+  local raw=${1:-}
+  local token
+  token=$(echo "${raw}" | tr -cs 'A-Za-z0-9._-' '-')
+  token=${token#-}
+  token=${token%-}
+  if [[ -z "${token}" ]]; then
+    token="unknown"
+  fi
+  echo "${token}"
+}
+
+json_get_string() {
+  local json=$1
+  local query=$2
+  jq -r "${query} // empty" <<<"${json}" 2>/dev/null || true
+}
+
+iso_to_epoch() {
+  local raw=${1:-}
+  if [[ -z "${raw}" ]]; then
+    echo 0
+    return 0
+  fi
+  python3 - "${raw}" <<'PY'
+import datetime
+import sys
+raw = sys.argv[1]
+try:
+    dt = datetime.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    print(int(dt.timestamp()))
+except Exception:
+    print(0)
+PY
+}
+
+backoff_seconds() {
+  local attempt=$1
+  local delay=$((SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS * (2 ** (attempt - 1))))
+  if (( delay > SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS )); then
+    delay=${SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS}
+  fi
+  local jitter=$((RANDOM % (SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS + 1)))
+  delay=$((delay + jitter))
+  if (( delay > SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS )); then
+    delay=${SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS}
+  fi
+  echo "${delay}"
+}
+
+s3_put_json() {
+  local key=$1
+  local payload=$2
+  local tmp
+  tmp=$(mktemp)
+  printf '%s' "${payload}" >"${tmp}"
+  local rc=0
+  retry_cmd 5 5 aws_cli s3api put-object \
+    --bucket "${SCFUZZBENCH_S3_BUCKET}" \
+    --key "${key}" \
+    --content-type application/json \
+    --body "${tmp}" \
+    >/dev/null || rc=$?
+  rm -f "${tmp}"
+  return "${rc}"
+}
+
+s3_get_json() {
+  local key=$1
+  local out_file=$2
+  local meta_file
+  local err_file
+  meta_file=$(mktemp)
+  err_file=$(mktemp)
+
+  if aws_cli s3api get-object \
+    --bucket "${SCFUZZBENCH_S3_BUCKET}" \
+    --key "${key}" \
+    "${out_file}" \
+    --output json >"${meta_file}" 2>"${err_file}"; then
+    rm -f "${meta_file}" "${err_file}"
+    return 0
+  fi
+
+  local err
+  err=$(cat "${err_file}")
+  rm -f "${meta_file}" "${err_file}"
+  if grep -Eq "NoSuchKey|Not Found|status code: 404" <<<"${err}"; then
+    return 1
+  fi
+  log "Failed to read s3://${SCFUZZBENCH_S3_BUCKET}/${key}: ${err}"
+  return 2
+}
+
+s3_delete_key() {
+  local key=$1
+  aws_cli s3api delete-object --bucket "${SCFUZZBENCH_S3_BUCKET}" --key "${key}" >/dev/null 2>&1 || true
+}
+
+s3_list_keys() {
+  local prefix=$1
+  local token=""
+  while true; do
+    local payload
+    if [[ -n "${token}" ]]; then
+      payload=$(aws_cli s3api list-objects-v2 \
+        --bucket "${SCFUZZBENCH_S3_BUCKET}" \
+        --prefix "${prefix}" \
+        --continuation-token "${token}" \
+        --output json 2>/dev/null || true)
+    else
+      payload=$(aws_cli s3api list-objects-v2 \
+        --bucket "${SCFUZZBENCH_S3_BUCKET}" \
+        --prefix "${prefix}" \
+        --output json 2>/dev/null || true)
+    fi
+
+    if [[ -z "${payload}" ]]; then
+      return 0
+    fi
+
+    jq -r '.Contents[]?.Key' <<<"${payload}"
+
+    local truncated
+    truncated=$(jq -r '.IsTruncated // false' <<<"${payload}")
+    if [[ "${truncated}" != "true" ]]; then
+      break
+    fi
+    token=$(jq -r '.NextContinuationToken // empty' <<<"${payload}")
+    if [[ -z "${token}" ]]; then
+      break
+    fi
+  done
+}
+
+write_event() {
+  local shard_key=$1
+  local status=$2
+  local attempt=${3:-0}
+  local message=${4:-}
+  local ts_ms
+  ts_ms=$(epoch_ms_now)
+  local safe_shard
+  safe_shard=$(safe_token "${shard_key}")
+  local safe_status
+  safe_status=$(safe_token "${status}")
+  local key="${EVENT_PREFIX}/${ts_ms}-${INSTANCE_ID_SAFE}-${safe_shard}-${safe_status}.json"
+  local payload
+  payload=$(jq -cn \
+    --arg ts "$(iso_now)" \
+    --arg run_id "${SCFUZZBENCH_RUN_ID}" \
+    --arg benchmark_uuid "${SCFUZZBENCH_BENCHMARK_UUID}" \
+    --arg shard_key "${shard_key}" \
+    --arg status "${status}" \
+    --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" \
+    --arg message "${message}" \
+    --argjson attempt "${attempt}" \
+    --argjson ts_epoch_ms "${ts_ms}" \
+    '{
+      ts: $ts,
+      ts_epoch_ms: $ts_epoch_ms,
+      run_id: $run_id,
+      benchmark_uuid: $benchmark_uuid,
+      shard_key: $shard_key,
+      status: $status,
+      attempt: $attempt,
+      instance_id: $instance_id,
+      message: $message
+    }')
+  s3_put_json "${key}" "${payload}" || true
+}
+
+write_worker_status() {
+  local state=$1
+  local shard_key=${2:-}
+  local attempt=${3:-0}
+  local message=${4:-}
+  local key="${STATUS_PREFIX}/workers/${SCFUZZBENCH_INSTANCE_ID:-unknown}.json"
+  local payload
+  payload=$(jq -cn \
+    --arg ts "$(iso_now)" \
+    --arg run_id "${SCFUZZBENCH_RUN_ID}" \
+    --arg benchmark_uuid "${SCFUZZBENCH_BENCHMARK_UUID}" \
+    --arg state "${state}" \
+    --arg shard_key "${shard_key}" \
+    --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" \
+    --arg message "${message}" \
+    --argjson attempt "${attempt}" \
+    '{
+      ts: $ts,
+      run_id: $run_id,
+      benchmark_uuid: $benchmark_uuid,
+      state: $state,
+      shard_key: $shard_key,
+      attempt: $attempt,
+      instance_id: $instance_id,
+      message: $message
+    }')
+  s3_put_json "${key}" "${payload}" || true
+}
+
+read_run_status_json() {
+  local tmp
+  tmp=$(mktemp)
+  if ! s3_get_json "${RUN_STATUS_KEY}" "${tmp}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
+  cat "${tmp}"
+  rm -f "${tmp}"
+}
+
+refresh_run_status() {
+  local keys
+  keys=$(s3_list_keys "${SHARD_PREFIX}/" | sort)
+  local queued=0
+  local running=0
+  local retrying=0
+  local succeeded=0
+  local failed=0
+  local timed_out=0
+  local unknown=0
+
+  if [[ -n "${keys}" ]]; then
+    while IFS= read -r key; do
+      [[ -z "${key}" ]] && continue
+      local tmp
+      tmp=$(mktemp)
+      if ! s3_get_json "${key}" "${tmp}"; then
+        rm -f "${tmp}"
+        continue
+      fi
+      local status
+      status=$(jq -r '.status // empty' "${tmp}")
+      rm -f "${tmp}"
+      case "${status}" in
+        queued) queued=$((queued + 1)) ;;
+        running) running=$((running + 1)) ;;
+        retrying) retrying=$((retrying + 1)) ;;
+        succeeded) succeeded=$((succeeded + 1)) ;;
+        failed) failed=$((failed + 1)) ;;
+        timed_out) timed_out=$((timed_out + 1)) ;;
+        *) unknown=$((unknown + 1)) ;;
+      esac
+    done <<<"${keys}"
+  fi
+
+  local requested=$((queued + running + retrying + succeeded + failed + timed_out + unknown))
+  local status="running"
+  if (( queued == 0 && running == 0 && retrying == 0 )); then
+    if (( failed > 0 || timed_out > 0 )); then
+      status="failed"
+    else
+      status="completed"
+    fi
+  fi
+
+  local old_status=""
+  local existing
+  if existing=$(read_run_status_json 2>/dev/null); then
+    old_status=$(json_get_string "${existing}" '.status')
+  fi
+
+  local payload
+  payload=$(jq -cn \
+    --arg ts "$(iso_now)" \
+    --arg run_id "${SCFUZZBENCH_RUN_ID}" \
+    --arg benchmark_uuid "${SCFUZZBENCH_BENCHMARK_UUID}" \
+    --arg status "${status}" \
+    --arg queue_backend "s3" \
+    --argjson requested "${requested}" \
+    --argjson max_parallel "${SCFUZZBENCH_MAX_PARALLEL_EFFECTIVE:-1}" \
+    --argjson shard_max_attempts "${SCFUZZBENCH_SHARD_MAX_ATTEMPTS}" \
+    --argjson queued "${queued}" \
+    --argjson running "${running}" \
+    --argjson retrying "${retrying}" \
+    --argjson succeeded "${succeeded}" \
+    --argjson failed "${failed}" \
+    --argjson timed_out "${timed_out}" \
+    --argjson unknown "${unknown}" \
+    --argjson updated_epoch "$(epoch_now)" \
+    '{
+      ts: $ts,
+      run_id: $run_id,
+      benchmark_uuid: $benchmark_uuid,
+      queue_backend: $queue_backend,
+      status: $status,
+      requested_shards: $requested,
+      max_parallel_instances: $max_parallel,
+      shard_max_attempts: $shard_max_attempts,
+      queued_count: $queued,
+      running_count: $running,
+      retrying_count: $retrying,
+      succeeded_count: $succeeded,
+      failed_count: $failed,
+      timed_out_count: $timed_out,
+      unknown_count: $unknown,
+      updated_epoch: $updated_epoch,
+      updated_at: $ts
+    }')
+
+  if [[ "${status}" == "completed" || "${status}" == "failed" ]]; then
+    payload=$(jq -c '. + {completed_at: .updated_at}' <<<"${payload}")
+  fi
+
+  s3_put_json "${RUN_STATUS_KEY}" "${payload}" || true
+
+  if [[ -n "${status}" && "${status}" != "${old_status}" ]]; then
+    write_event "run" "${status}" 0 "run status transition"
+  fi
+
+  echo "${status}"
+}
+
+update_manifest_final_fields() {
+  local status=$1
+  local run_status_json=$2
+  local tmp_manifest
+  tmp_manifest=$(mktemp)
+  local logs_manifest_key="logs/${SCFUZZBENCH_RUN_ID}/${SCFUZZBENCH_BENCHMARK_UUID}/manifest.json"
+  if ! s3_get_json "${logs_manifest_key}" "${tmp_manifest}"; then
+    rm -f "${tmp_manifest}"
+    return 0
+  fi
+
+  local merged
+  merged=$(jq -c \
+    --arg status "${status}" \
+    --arg completed_at "$(iso_now)" \
+    --argjson requested "$(jq -r '.requested_shards // 0' <<<"${run_status_json}")" \
+    --argjson succeeded "$(jq -r '.succeeded_count // 0' <<<"${run_status_json}")" \
+    --argjson failed "$(jq -r '(.failed_count // 0) + (.timed_out_count // 0)' <<<"${run_status_json}")" \
+    '. + {
+      final_status: $status,
+      final_requested_shards: $requested,
+      final_succeeded_shards: $succeeded,
+      final_failed_shards: $failed,
+      completed_at: $completed_at
+    }' "${tmp_manifest}")
+  rm -f "${tmp_manifest}"
+
+  local out
+  out=$(mktemp)
+  printf '%s' "${merged}" >"${out}"
+  retry_cmd 5 5 aws_cli s3 cp "${out}" "s3://${SCFUZZBENCH_S3_BUCKET}/${logs_manifest_key}" --no-progress >/dev/null || true
+  retry_cmd 5 5 aws_cli s3 cp "${out}" "s3://${SCFUZZBENCH_S3_BUCKET}/runs/${SCFUZZBENCH_RUN_ID}/${SCFUZZBENCH_BENCHMARK_UUID}/manifest.json" --no-progress >/dev/null || true
+  rm -f "${out}"
+}
+
+release_lock_if_owner() {
+  local lock_tmp
+  lock_tmp=$(mktemp)
+  if ! s3_get_json "${SCFUZZBENCH_LOCK_OBJECT_KEY}" "${lock_tmp}"; then
+    rm -f "${lock_tmp}"
+    return 0
+  fi
+  local owner
+  owner=$(jq -r '.owner_run_id // empty' "${lock_tmp}")
+  rm -f "${lock_tmp}"
+  if [[ "${owner}" == "${SCFUZZBENCH_RUN_ID}" ]]; then
+    s3_delete_key "${SCFUZZBENCH_LOCK_OBJECT_KEY}"
+  fi
+}
+
+force_run_failed() {
+  local reason=$1
+  local current_status
+  current_status=$(refresh_run_status)
+  local run_json
+  if ! run_json=$(read_run_status_json); then
+    return 0
+  fi
+  local failed_payload
+  failed_payload=$(jq -c --arg reason "${reason}" --arg completed_at "$(iso_now)" '. + {status:"failed", failure_reason:$reason, completed_at:$completed_at}' <<<"${run_json}")
+  s3_put_json "${RUN_STATUS_KEY}" "${failed_payload}" || true
+  write_event "run" "failed" 0 "${reason}"
+  update_manifest_final_fields "failed" "${failed_payload}"
+  if [[ "${current_status}" != "failed" ]]; then
+    release_lock_if_owner || true
+  fi
+}
+
+renew_lock_once() {
+  local tmp
+  tmp=$(mktemp)
+  if ! s3_get_json "${SCFUZZBENCH_LOCK_OBJECT_KEY}" "${tmp}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
+  local owner
+  owner=$(jq -r '.owner_run_id // empty' "${tmp}")
+  if [[ "${owner}" != "${SCFUZZBENCH_RUN_ID}" ]]; then
+    rm -f "${tmp}"
+    return 1
+  fi
+  local updated
+  updated=$(jq -c \
+    --arg now "$(iso_now)" \
+    --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" \
+    --argjson lease "${SCFUZZBENCH_LOCK_LEASE_SECONDS}" \
+    --argjson now_epoch "$(epoch_now)" \
+    '. + {
+      updated_at: $now,
+      heartbeat_instance_id: $instance_id,
+      expires_at_epoch: ($now_epoch + $lease)
+    }' "${tmp}")
+  rm -f "${tmp}"
+  s3_put_json "${SCFUZZBENCH_LOCK_OBJECT_KEY}" "${updated}"
+}
+
+start_lock_heartbeat() {
+  (
+    local consecutive_failures=0
+    while true; do
+      sleep "${SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS}" || true
+      if renew_lock_once; then
+        consecutive_failures=0
+      else
+        consecutive_failures=$((consecutive_failures + 1))
+        log "Lock heartbeat failed (${consecutive_failures}/${SCFUZZBENCH_LOCK_HEARTBEAT_MAX_FAILURES})"
+        if (( consecutive_failures >= SCFUZZBENCH_LOCK_HEARTBEAT_MAX_FAILURES )); then
+          touch "${LOCK_FAILURE_MARKER}"
+          break
+        fi
+      fi
+    done
+  ) &
+  SCFUZZBENCH_LOCK_HEARTBEAT_PID=$!
+}
+
+stop_lock_heartbeat() {
+  local pid=${SCFUZZBENCH_LOCK_HEARTBEAT_PID:-}
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    kill "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+  fi
+}
+
+wait_for_run_status_bootstrap() {
+  local waited=0
+  while (( waited < SCFUZZBENCH_QUEUE_BOOTSTRAP_WAIT_SECONDS )); do
+    local tmp
+    tmp=$(mktemp)
+    if s3_get_json "${RUN_STATUS_KEY}" "${tmp}"; then
+      local status
+      status=$(jq -r '.status // empty' "${tmp}")
+      rm -f "${tmp}"
+      if [[ "${status}" == "running" || "${status}" == "completed" || "${status}" == "failed" ]]; then
+        return 0
+      fi
+    else
+      rm -f "${tmp}"
+    fi
+    write_worker_status "waiting" "" 0 "waiting for queue bootstrap"
+    sleep 10
+    waited=$((waited + 10))
+  done
+  return 1
+}
+
+build_claim_payload() {
+  local shard_key=$1
+  local claim_key=$2
+  jq -cn \
+    --arg ts "$(iso_now)" \
+    --arg run_id "${SCFUZZBENCH_RUN_ID}" \
+    --arg benchmark_uuid "${SCFUZZBENCH_BENCHMARK_UUID}" \
+    --arg shard_key "${shard_key}" \
+    --arg claim_key "${claim_key}" \
+    --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" \
+    '{
+      ts: $ts,
+      run_id: $run_id,
+      benchmark_uuid: $benchmark_uuid,
+      shard_key: $shard_key,
+      claim_key: $claim_key,
+      instance_id: $instance_id
+    }'
+}
+
+create_claim() {
+  local shard_key=$1
+  local ts_ms
+  ts_ms=$(epoch_ms_now)
+  local nonce
+  nonce=$(printf '%08x' $((RANDOM * RANDOM + 1)))
+  local claim_key="${CLAIM_PREFIX}/${shard_key}/${ts_ms}-${INSTANCE_ID_SAFE}-${nonce}.json"
+  local payload
+  payload=$(build_claim_payload "${shard_key}" "${claim_key}")
+  s3_put_json "${claim_key}" "${payload}" || return 1
+  echo "${claim_key}"
+}
+
+claim_epoch_from_key() {
+  local key=$1
+  local base
+  base=$(basename "${key}")
+  echo "${base}" | sed -E 's/^([0-9]+)-.*$/\1/'
+}
+
+cleanup_stale_claims() {
+  local shard_key=$1
+  local claim_keys
+  claim_keys=$(s3_list_keys "${CLAIM_PREFIX}/${shard_key}/")
+  if [[ -z "${claim_keys}" ]]; then
+    return 0
+  fi
+  local now_ms
+  now_ms=$(epoch_ms_now)
+  while IFS= read -r key; do
+    [[ -z "${key}" ]] && continue
+    local claim_ms
+    claim_ms=$(claim_epoch_from_key "${key}")
+    if ! [[ "${claim_ms}" =~ ^[0-9]+$ ]]; then
+      continue
+    fi
+    local age=$(((now_ms - claim_ms) / 1000))
+    if (( age > SCFUZZBENCH_CLAIM_STALE_SECONDS )); then
+      s3_delete_key "${key}"
+    fi
+  done <<<"${claim_keys}"
+}
+
+is_claim_leader() {
+  local shard_key=$1
+  local my_claim=$2
+  cleanup_stale_claims "${shard_key}"
+  local keys
+  keys=$(s3_list_keys "${CLAIM_PREFIX}/${shard_key}/" | sort)
+  if [[ -z "${keys}" ]]; then
+    return 1
+  fi
+  local first
+  first=$(head -n 1 <<<"${keys}")
+  [[ "${first}" == "${my_claim}" ]]
+}
+
+set_shard_state() {
+  local key=$1
+  local payload=$2
+  s3_put_json "${key}" "${payload}"
+}
+
+reclaim_stale_running_shard() {
+  local shard_key=$1
+  local key=$2
+  local shard_json=$3
+
+  local updated_at
+  updated_at=$(json_get_string "${shard_json}" '.updated_at')
+  local updated_epoch
+  updated_epoch=$(iso_to_epoch "${updated_at}")
+  local now
+  now=$(epoch_now)
+  local age=$((now - updated_epoch))
+  if (( age < SCFUZZBENCH_RUNNING_STALE_SECONDS )); then
+    return 0
+  fi
+
+  local attempt
+  attempt=$(json_get_string "${shard_json}" '.attempt')
+  if ! [[ "${attempt}" =~ ^[0-9]+$ ]]; then
+    attempt=1
+  fi
+
+  if (( attempt >= SCFUZZBENCH_SHARD_MAX_ATTEMPTS )); then
+    local terminal
+    terminal=$(jq -c \
+      --arg now_iso "$(iso_now)" \
+      --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" \
+      '. + {
+        status: "failed",
+        last_error: "stale running shard reclaimed at max attempts",
+        last_exit_code: 903,
+        completed_at: $now_iso,
+        updated_at: $now_iso,
+        completed_by: $instance_id
+      }' <<<"${shard_json}")
+    set_shard_state "${key}" "${terminal}" || true
+    write_event "${shard_key}" "failed" "${attempt}" "stale running shard terminalized"
+    local dlq_payload
+    dlq_payload=$(jq -c '. + {dlq_reason:"stale_running_max_attempts"}' <<<"${terminal}")
+    s3_put_json "${DLQ_PREFIX}/${shard_key}-${attempt}.json" "${dlq_payload}" || true
+    return 0
+  fi
+
+  local delay
+  delay=$(backoff_seconds "${attempt}")
+  local next_epoch=$((now + delay))
+  local retrying
+  retrying=$(jq -c \
+    --arg now_iso "$(iso_now)" \
+    --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" \
+    --arg next_iso "$(date -u -d "@${next_epoch}" +"%Y-%m-%dT%H:%M:%SZ")" \
+    --argjson delay "${delay}" \
+    '. + {
+      status: "retrying",
+      last_error: ("stale running shard reclaimed; retry in " + ($delay|tostring) + "s"),
+      last_exit_code: 903,
+      updated_at: $now_iso,
+      next_attempt_at: $next_iso,
+      reclaimed_by: $instance_id
+    }' <<<"${shard_json}")
+  set_shard_state "${key}" "${retrying}" || true
+  write_event "${shard_key}" "retrying" "${attempt}" "reclaimed stale running shard"
+}
+
+shard_ready_for_claim() {
+  local shard_json=$1
+  local status
+  status=$(json_get_string "${shard_json}" '.status' | tr '[:upper:]' '[:lower:]')
+  if [[ "${status}" == "queued" ]]; then
+    return 0
+  fi
+  if [[ "${status}" != "retrying" ]]; then
+    return 1
+  fi
+  local next_attempt_at
+  next_attempt_at=$(json_get_string "${shard_json}" '.next_attempt_at')
+  local next_epoch
+  next_epoch=$(iso_to_epoch "${next_attempt_at}")
+  local now
+  now=$(epoch_now)
+  (( now >= next_epoch ))
+}
+
+CLAIMED_SHARD_KEY=""
+CLAIMED_STATE_KEY=""
+CLAIMED_FUZZER_KEY=""
+CLAIMED_RUN_INDEX=""
+CLAIMED_ATTEMPT=""
+CLAIMED_CLAIM_KEY=""
+
+claim_shard() {
+  local key=$1
+  local shard_key
+  shard_key=$(basename "${key}" .json)
+
+  local tmp
+  tmp=$(mktemp)
+  if ! s3_get_json "${key}" "${tmp}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
+  local shard_json
+  shard_json=$(cat "${tmp}")
+  rm -f "${tmp}"
+
+  local status
+  status=$(json_get_string "${shard_json}" '.status' | tr '[:upper:]' '[:lower:]')
+  if [[ "${status}" == "running" ]]; then
+    reclaim_stale_running_shard "${shard_key}" "${key}" "${shard_json}"
+    return 1
+  fi
+
+  if ! shard_ready_for_claim "${shard_json}"; then
+    return 1
+  fi
+
+  local claim_key
+  claim_key=$(create_claim "${shard_key}") || return 1
+
+  sleep "${SCFUZZBENCH_CLAIM_SETTLE_SECONDS}"
+  if ! is_claim_leader "${shard_key}" "${claim_key}"; then
+    s3_delete_key "${claim_key}"
+    return 1
+  fi
+
+  tmp=$(mktemp)
+  if ! s3_get_json "${key}" "${tmp}"; then
+    rm -f "${tmp}"
+    s3_delete_key "${claim_key}"
+    return 1
+  fi
+  shard_json=$(cat "${tmp}")
+  rm -f "${tmp}"
+
+  if ! shard_ready_for_claim "${shard_json}"; then
+    s3_delete_key "${claim_key}"
+    return 1
+  fi
+
+  local attempt
+  attempt=$(json_get_string "${shard_json}" '.attempt')
+  if ! [[ "${attempt}" =~ ^[0-9]+$ ]]; then
+    attempt=0
+  fi
+  attempt=$((attempt + 1))
+
+  local claimed
+  claimed=$(jq -c \
+    --arg now_iso "$(iso_now)" \
+    --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" \
+    --arg claim_key "${claim_key}" \
+    --argjson attempt "${attempt}" \
+    '. + {
+      status: "running",
+      attempt: $attempt,
+      claimed_by: $instance_id,
+      claim_key: $claim_key,
+      started_at: $now_iso,
+      updated_at: $now_iso,
+      next_attempt_at: $now_iso
+    }' <<<"${shard_json}")
+
+  set_shard_state "${key}" "${claimed}" || {
+    s3_delete_key "${claim_key}"
+    return 1
+  }
+
+  CLAIMED_SHARD_KEY=${shard_key}
+  CLAIMED_STATE_KEY=${key}
+  CLAIMED_FUZZER_KEY=$(json_get_string "${claimed}" '.fuzzer_key')
+  CLAIMED_RUN_INDEX=$(json_get_string "${claimed}" '.run_index')
+  CLAIMED_ATTEMPT=${attempt}
+  CLAIMED_CLAIM_KEY=${claim_key}
+
+  if [[ -z "${CLAIMED_FUZZER_KEY}" || ! "${CLAIMED_RUN_INDEX}" =~ ^[0-9]+$ ]]; then
+    s3_delete_key "${claim_key}"
+    return 1
+  fi
+
+  write_event "${CLAIMED_SHARD_KEY}" "running" "${CLAIMED_ATTEMPT}" "claimed shard"
+  return 0
+}
+
+claim_next_shard() {
+  CLAIMED_SHARD_KEY=""
+  CLAIMED_STATE_KEY=""
+  CLAIMED_FUZZER_KEY=""
+  CLAIMED_RUN_INDEX=""
+  CLAIMED_ATTEMPT=""
+  CLAIMED_CLAIM_KEY=""
+
+  local keys
+  keys=$(s3_list_keys "${SHARD_PREFIX}/")
+  if [[ -z "${keys}" ]]; then
+    return 1
+  fi
+
+  while IFS= read -r key; do
+    [[ -z "${key}" ]] && continue
+    if claim_shard "${key}"; then
+      return 0
+    fi
+  done <<<"$(sort <<<"${keys}")"
+
+  return 1
+}
+
+heartbeat_running_shard() {
+  local state_key=$1
+  local attempt=$2
+  while true; do
+    sleep "${SCFUZZBENCH_SHARD_HEARTBEAT_SECONDS}" || true
+    local tmp
+    tmp=$(mktemp)
+    if ! s3_get_json "${state_key}" "${tmp}"; then
+      rm -f "${tmp}"
+      break
+    fi
+    local status
+    status=$(jq -r '.status // empty' "${tmp}")
+    local current_attempt
+    current_attempt=$(jq -r '.attempt // 0' "${tmp}")
+    if [[ "${status}" != "running" || "${current_attempt}" != "${attempt}" ]]; then
+      rm -f "${tmp}"
+      break
+    fi
+
+    local updated
+    updated=$(jq -c --arg now_iso "$(iso_now)" --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" '. + {updated_at:$now_iso, heartbeat_instance_id:$instance_id}' "${tmp}")
+    rm -f "${tmp}"
+    set_shard_state "${state_key}" "${updated}" || true
+  done
+}
+
+write_dlq_entry() {
+  local shard_key=$1
+  local attempt=$2
+  local payload=$3
+  s3_put_json "${DLQ_PREFIX}/${shard_key}-${attempt}.json" "${payload}" || true
+}
+
+finalize_claimed_shard() {
+  local result_status=$1
+  local exit_code=$2
+  local message=$3
+
+  local tmp
+  tmp=$(mktemp)
+  if ! s3_get_json "${CLAIMED_STATE_KEY}" "${tmp}"; then
+    rm -f "${tmp}"
+    s3_delete_key "${CLAIMED_CLAIM_KEY}"
+    return 1
+  fi
+  local shard_json
+  shard_json=$(cat "${tmp}")
+  rm -f "${tmp}"
+
+  local payload
+  payload=$(jq -c \
+    --arg status "${result_status}" \
+    --arg now_iso "$(iso_now)" \
+    --arg msg "${message}" \
+    --arg instance_id "${SCFUZZBENCH_INSTANCE_ID:-unknown}" \
+    --argjson exit_code "${exit_code}" \
+    '. + {
+      status: $status,
+      updated_at: $now_iso,
+      last_error: $msg,
+      last_exit_code: $exit_code,
+      completed_by: $instance_id
+    }' <<<"${shard_json}")
+
+  if [[ "${result_status}" == "succeeded" || "${result_status}" == "failed" || "${result_status}" == "timed_out" ]]; then
+    payload=$(jq -c '. + {completed_at: .updated_at}' <<<"${payload}")
+  fi
+
+  set_shard_state "${CLAIMED_STATE_KEY}" "${payload}" || true
+  write_event "${CLAIMED_SHARD_KEY}" "${result_status}" "${CLAIMED_ATTEMPT}" "${message}"
+
+  if [[ "${result_status}" == "failed" || "${result_status}" == "timed_out" ]]; then
+    write_dlq_entry "${CLAIMED_SHARD_KEY}" "${CLAIMED_ATTEMPT}" "${payload}"
+  fi
+
+  s3_delete_key "${CLAIMED_CLAIM_KEY}"
+}
+
+retry_claimed_shard() {
+  local exit_code=$1
+  local message=$2
+
+  local delay
+  delay=$(backoff_seconds "${CLAIMED_ATTEMPT}")
+  local next_epoch=$(( $(epoch_now) + delay ))
+  local next_iso
+  next_iso=$(date -u -d "@${next_epoch}" +"%Y-%m-%dT%H:%M:%SZ")
+
+  local tmp
+  tmp=$(mktemp)
+  if ! s3_get_json "${CLAIMED_STATE_KEY}" "${tmp}"; then
+    rm -f "${tmp}"
+    s3_delete_key "${CLAIMED_CLAIM_KEY}"
+    return 1
+  fi
+  local shard_json
+  shard_json=$(cat "${tmp}")
+  rm -f "${tmp}"
+
+  local payload
+  payload=$(jq -c \
+    --arg now_iso "$(iso_now)" \
+    --arg next_iso "${next_iso}" \
+    --arg msg "${message}" \
+    --argjson delay "${delay}" \
+    --argjson exit_code "${exit_code}" \
+    '. + {
+      status: "retrying",
+      updated_at: $now_iso,
+      next_attempt_at: $next_iso,
+      last_error: ($msg + "; retry in " + ($delay|tostring) + "s"),
+      last_exit_code: $exit_code
+    }' <<<"${shard_json}")
+
+  set_shard_state "${CLAIMED_STATE_KEY}" "${payload}" || true
+  write_event "${CLAIMED_SHARD_KEY}" "retrying" "${CLAIMED_ATTEMPT}" "${message}"
+  s3_delete_key "${CLAIMED_CLAIM_KEY}"
+}
+
+ensure_fuzzer_installed() {
+  local fuzzer_key=$1
+  local marker="/opt/scfuzzbench/.installed-${fuzzer_key}"
+  if [[ -f "${marker}" ]]; then
+    return 0
+  fi
+
+  local install_script="/opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh"
+  if [[ ! -x "${install_script}" ]]; then
+    log "Missing install script: ${install_script}"
+    return 1
+  fi
+
+  log "Installing fuzzer '${fuzzer_key}'"
+  if ! bash "${install_script}"; then
+    log "Fuzzer install failed: ${fuzzer_key}"
+    return 1
+  fi
+
+  touch "${marker}"
+  return 0
+}
+
+run_claimed_shard() {
+  write_worker_status "running" "${CLAIMED_SHARD_KEY}" "${CLAIMED_ATTEMPT}" "processing shard"
+
+  local install_rc=0
+  ensure_fuzzer_installed "${CLAIMED_FUZZER_KEY}" || install_rc=$?
+  if (( install_rc != 0 )); then
+    if (( CLAIMED_ATTEMPT >= SCFUZZBENCH_SHARD_MAX_ATTEMPTS )); then
+      finalize_claimed_shard "failed" "${install_rc}" "install failed at max attempts"
+    else
+      retry_claimed_shard "${install_rc}" "install failed"
+    fi
+    return
+  fi
+
+  heartbeat_running_shard "${CLAIMED_STATE_KEY}" "${CLAIMED_ATTEMPT}" &
+  local hb_pid=$!
+
+  local shard_root="/opt/scfuzzbench/shards/${CLAIMED_SHARD_KEY}-a${CLAIMED_ATTEMPT}"
+  mkdir -p "${shard_root}/work" "${shard_root}/logs" "${shard_root}/corpus"
+
+  local artifact_suffix="${CLAIMED_SHARD_KEY}-a${CLAIMED_ATTEMPT}"
+  local run_rc=0
+  set +e
+  SCFUZZBENCH_QUEUE_MODE=1 \
+    SCFUZZBENCH_ARTIFACT_SUFFIX="${artifact_suffix}" \
+    SCFUZZBENCH_WORKDIR="${shard_root}/work" \
+    SCFUZZBENCH_LOG_DIR="${shard_root}/logs" \
+    SCFUZZBENCH_CORPUS_DIR="${shard_root}/corpus" \
+    bash "/opt/scfuzzbench/fuzzers/${CLAIMED_FUZZER_KEY}/run.sh"
+  run_rc=$?
+  set -e
+
+  kill "${hb_pid}" >/dev/null 2>&1 || true
+  wait "${hb_pid}" >/dev/null 2>&1 || true
+
+  if (( run_rc == 0 )); then
+    finalize_claimed_shard "succeeded" 0 "shard succeeded"
+    return
+  fi
+
+  local terminal_status="failed"
+  if (( run_rc == 124 || run_rc == 137 )); then
+    terminal_status="timed_out"
+  fi
+
+  if (( CLAIMED_ATTEMPT >= SCFUZZBENCH_SHARD_MAX_ATTEMPTS )); then
+    finalize_claimed_shard "${terminal_status}" "${run_rc}" "terminal at max attempts"
+    return
+  fi
+
+  retry_claimed_shard "${run_rc}" "non-terminal failure"
+}
+
+main() {
+  log "Starting S3 queue worker for run ${SCFUZZBENCH_RUN_ID}/${SCFUZZBENCH_BENCHMARK_UUID}"
+
+  if ! wait_for_run_status_bootstrap; then
+    log "Queue bootstrap status did not appear in time"
+    write_worker_status "failed" "" 0 "missing bootstrap status"
+    exit 1
+  fi
+
+  start_lock_heartbeat
+
+  local idle_polls=0
+  while true; do
+    if [[ -f "${LOCK_FAILURE_MARKER}" ]]; then
+      log "Lock heartbeat failed repeatedly; fail-closed"
+      force_run_failed "lock heartbeat failures"
+      write_worker_status "failed" "" 0 "lock heartbeat failures"
+      stop_lock_heartbeat
+      exit 1
+    fi
+
+    if claim_next_shard; then
+      idle_polls=0
+      run_claimed_shard
+      local status_after
+      status_after=$(refresh_run_status)
+      if [[ "${status_after}" == "completed" || "${status_after}" == "failed" ]]; then
+        local run_json
+        if run_json=$(read_run_status_json 2>/dev/null); then
+          update_manifest_final_fields "${status_after}" "${run_json}"
+        fi
+        release_lock_if_owner || true
+      fi
+      continue
+    fi
+
+    idle_polls=$((idle_polls + 1))
+    write_worker_status "idle" "" 0 "idle poll ${idle_polls}"
+
+    local run_status
+    run_status=$(refresh_run_status)
+    if [[ "${run_status}" == "completed" || "${run_status}" == "failed" ]]; then
+      local run_json
+      if run_json=$(read_run_status_json 2>/dev/null); then
+        update_manifest_final_fields "${run_status}" "${run_json}"
+      fi
+      release_lock_if_owner || true
+      break
+    fi
+
+    if (( idle_polls >= SCFUZZBENCH_QUEUE_IDLE_POLLS )); then
+      local final_status
+      final_status=$(refresh_run_status)
+      if [[ "${final_status}" == "completed" || "${final_status}" == "failed" ]]; then
+        local run_json
+        if run_json=$(read_run_status_json 2>/dev/null); then
+          update_manifest_final_fields "${final_status}" "${run_json}"
+        fi
+        release_lock_if_owner || true
+        break
+      fi
+      idle_polls=0
+    fi
+
+    sleep "${SCFUZZBENCH_QUEUE_EMPTY_SLEEP_SECONDS}"
+  done
+
+  stop_lock_heartbeat
+  write_worker_status "completed" "" 0 "worker exiting"
+  log "Queue worker completed"
+}
+
+main "$@"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -11,21 +11,33 @@ locals {
 
   benchmark_manifest = merge(
     {
-      scfuzzbench_commit   = var.scfuzzbench_commit
-      target_repo_url      = var.target_repo_url
-      target_commit        = var.target_commit
-      benchmark_type       = var.benchmark_type
-      instance_type        = var.instance_type
-      instances_per_fuzzer = var.instances_per_fuzzer
-      timeout_hours        = var.timeout_hours
-      aws_region           = var.aws_region
-      ubuntu_ami_id        = data.aws_ssm_parameter.ubuntu_ami.value
-      foundry_version      = var.foundry_version
-      foundry_git_repo     = var.foundry_git_repo
-      foundry_git_ref      = var.foundry_git_ref
-      echidna_version      = var.echidna_version
-      medusa_version       = var.medusa_version
-      fuzzer_keys          = sort([for fuzzer in local.fuzzer_definitions : fuzzer.key])
+      scfuzzbench_commit            = var.scfuzzbench_commit
+      target_repo_url               = var.target_repo_url
+      target_commit                 = var.target_commit
+      benchmark_type                = var.benchmark_type
+      instance_type                 = var.instance_type
+      instances_per_fuzzer          = var.instances_per_fuzzer
+      timeout_hours                 = var.timeout_hours
+      aws_region                    = var.aws_region
+      ubuntu_ami_id                 = data.aws_ssm_parameter.ubuntu_ami.value
+      foundry_version               = var.foundry_version
+      foundry_git_repo              = var.foundry_git_repo
+      foundry_git_ref               = var.foundry_git_ref
+      echidna_version               = var.echidna_version
+      medusa_version                = var.medusa_version
+      fuzzer_keys                   = sort([for fuzzer in local.fuzzer_definitions : fuzzer.key])
+      queue_mode                    = true
+      queue_backend                 = "s3"
+      requested_shards              = local.requested_shard_count
+      max_parallel                  = local.max_parallel_effective
+      max_parallel_instances        = local.max_parallel_effective
+      shard_max_attempts            = var.shard_max_attempts
+      shard_retry_base_seconds      = var.shard_retry_base_seconds
+      shard_retry_max_seconds       = var.shard_retry_max_seconds
+      global_mutex                  = true
+      global_lock_name              = var.control_lock_name
+      global_lock_lease_seconds     = var.control_lock_lease_seconds
+      global_lock_heartbeat_seconds = var.control_lock_heartbeat_seconds
     },
     contains(local.selected_fuzzer_keys, "echidna-symexec") ? {
       bitwuzla_version = var.bitwuzla_version
@@ -71,14 +83,32 @@ locals {
   instances = flatten([
     for fuzzer in local.fuzzer_definitions : [
       for index in range(var.instances_per_fuzzer) : {
-        key       = "${fuzzer.key}-${index}"
-        fuzzer    = fuzzer
-        run_index = index
+        key        = "${fuzzer.key}-${index}"
+        fuzzer_key = fuzzer.key
+        run_index  = index
       }
     ]
   ])
 
-  instance_map = { for instance in local.instances : instance.key => instance }
+  requested_shard_count  = length(local.instances)
+  max_parallel_requested = var.max_parallel_instances > 0 ? var.max_parallel_instances : local.requested_shard_count
+  max_parallel_effective = max(1, min(local.max_parallel_requested, local.requested_shard_count))
+  worker_slots = [
+    for index in range(local.max_parallel_effective) : {
+      key  = "worker-${index}"
+      slot = index
+    }
+  ]
+  worker_map = { for worker in local.worker_slots : worker.key => worker }
+  fuzzer_scripts = {
+    for fuzzer in local.fuzzer_definitions : fuzzer.key => {
+      install_sh = file(fuzzer.install_path)
+      run_sh     = file(fuzzer.run_path)
+    }
+  }
+  run_prefix              = "runs/${local.run_id}/${local.benchmark_uuid}"
+  control_lock_prefix     = "runs/control/locks/${var.control_lock_name}"
+  control_lock_object_key = "${local.control_lock_prefix}/active.json"
 }
 
 resource "random_id" "suffix" {
@@ -272,6 +302,8 @@ data "aws_iam_policy_document" "s3_access" {
   statement {
     actions = [
       "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
       "s3:AbortMultipartUpload",
       "s3:ListBucket",
       "s3:GetBucketLocation",
@@ -329,7 +361,7 @@ resource "aws_iam_instance_profile" "fuzzer" {
 }
 
 resource "aws_instance" "fuzzer" {
-  for_each = local.instance_map
+  for_each = local.worker_map
 
   ami                         = data.aws_ssm_parameter.ubuntu_ami.value
   instance_type               = var.instance_type
@@ -341,27 +373,37 @@ resource "aws_instance" "fuzzer" {
   user_data_replace_on_change = true
 
   user_data_base64 = base64gzip(templatefile("${path.module}/user_data.sh.tftpl", {
-    fuzzer_key                   = each.value.fuzzer.key
-    shared_sh                    = file("${path.module}/../fuzzers/_shared/common.sh")
-    install_sh                   = file(each.value.fuzzer.install_path)
-    run_sh                       = file(each.value.fuzzer.run_path)
-    aws_region                   = var.aws_region
-    s3_bucket                    = local.bucket_name
-    run_id                       = local.run_id
-    benchmark_uuid               = local.benchmark_uuid
-    benchmark_manifest_b64       = local.benchmark_manifest_b64
-    timeout_seconds              = local.timeout_seconds
-    repo_url                     = var.target_repo_url
-    repo_commit                  = var.target_commit
-    benchmark_type               = var.benchmark_type
-    foundry_version              = var.foundry_version
-    foundry_git_repo             = var.foundry_git_repo
-    foundry_git_ref              = var.foundry_git_ref
-    echidna_version              = var.echidna_version
-    medusa_version               = var.medusa_version
-    bitwuzla_version             = var.bitwuzla_version
-    git_token_ssm_parameter_name = var.git_token_ssm_parameter_name
-    fuzzer_env                   = var.fuzzer_env
+    shared_sh                      = file("${path.module}/../fuzzers/_shared/common.sh")
+    queue_worker_sh                = file("${path.module}/../fuzzers/_shared/queue_worker.sh")
+    fuzzer_scripts                 = local.fuzzer_scripts
+    aws_region                     = var.aws_region
+    s3_bucket                      = local.bucket_name
+    run_id                         = local.run_id
+    benchmark_uuid                 = local.benchmark_uuid
+    benchmark_manifest_b64         = local.benchmark_manifest_b64
+    timeout_seconds                = local.timeout_seconds
+    repo_url                       = var.target_repo_url
+    repo_commit                    = var.target_commit
+    benchmark_type                 = var.benchmark_type
+    foundry_version                = var.foundry_version
+    foundry_git_repo               = var.foundry_git_repo
+    foundry_git_ref                = var.foundry_git_ref
+    echidna_version                = var.echidna_version
+    medusa_version                 = var.medusa_version
+    bitwuzla_version               = var.bitwuzla_version
+    git_token_ssm_parameter_name   = var.git_token_ssm_parameter_name
+    fuzzer_env                     = var.fuzzer_env
+    queue_idle_polls               = var.queue_idle_polls
+    queue_empty_sleep_seconds      = var.queue_empty_sleep_seconds
+    shard_max_attempts             = var.shard_max_attempts
+    shard_retry_base_seconds       = var.shard_retry_base_seconds
+    shard_retry_max_seconds        = var.shard_retry_max_seconds
+    running_stale_seconds          = var.running_stale_seconds
+    control_lock_name              = var.control_lock_name
+    control_lock_object_key        = local.control_lock_object_key
+    control_lock_lease_seconds     = var.control_lock_lease_seconds
+    control_lock_heartbeat_seconds = var.control_lock_heartbeat_seconds
+    max_parallel_effective         = local.max_parallel_effective
   }))
 
   root_block_device {
@@ -374,8 +416,7 @@ resource "aws_instance" "fuzzer" {
   }
 
   tags = merge(local.tags, {
-    Name     = "${local.name_prefix}-${each.value.fuzzer.key}-${each.value.run_index}"
-    Fuzzer   = each.value.fuzzer.key
-    RunIndex = tostring(each.value.run_index)
+    Name       = "${local.name_prefix}-worker-${each.value.slot}"
+    WorkerSlot = tostring(each.value.slot)
   })
 }

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -19,11 +19,37 @@ output "ssh_private_key_path" {
 }
 
 output "instance_ids" {
-  description = "Instance IDs by fuzzer and index."
+  description = "Worker instance IDs by slot."
   value       = { for key, instance in aws_instance.fuzzer : key => instance.id }
 }
 
 output "instance_public_ips" {
-  description = "Public IPs by fuzzer and index."
+  description = "Worker public IPs by slot."
   value       = { for key, instance in aws_instance.fuzzer : key => instance.public_ip }
+}
+
+output "requested_shards" {
+  description = "Total shard count requested for this run."
+  value       = local.requested_shard_count
+}
+
+output "max_parallel_effective" {
+  description = "Effective worker concurrency for this run."
+  value       = local.max_parallel_effective
+}
+
+output "shards" {
+  description = "Shard descriptors for this run."
+  value = [
+    for shard in local.instances : {
+      shard_key  = shard.key
+      fuzzer_key = shard.fuzzer_key
+      run_index  = shard.run_index
+    }
+  ]
+}
+
+output "control_lock_object_key" {
+  description = "S3 object key used for the global run lock lease."
+  value       = local.control_lock_object_key
 }

--- a/infrastructure/user_data.sh.tftpl
+++ b/infrastructure/user_data.sh.tftpl
@@ -9,23 +9,31 @@ fi
 
 systemctl enable --now ssh || systemctl enable --now sshd || true
 
-mkdir -p /opt/scfuzzbench/fuzzers/${fuzzer_key}
+mkdir -p /opt/scfuzzbench/fuzzers
 
 cat <<'SHARED' >/opt/scfuzzbench/common.sh
 ${shared_sh}
 SHARED
 
-cat <<'INSTALL' >/opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh
-${install_sh}
-INSTALL
+cat <<'QUEUE_WORKER' >/opt/scfuzzbench/queue_worker.sh
+${queue_worker_sh}
+QUEUE_WORKER
 
-cat <<'RUN' >/opt/scfuzzbench/fuzzers/${fuzzer_key}/run.sh
-${run_sh}
-RUN
+%{ for fuzzer_key, scripts in fuzzer_scripts ~}
+mkdir -p /opt/scfuzzbench/fuzzers/${fuzzer_key}
 
-chmod +x /opt/scfuzzbench/common.sh \
-  /opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh \
-  /opt/scfuzzbench/fuzzers/${fuzzer_key}/run.sh
+cat <<'INSTALL_${fuzzer_key}' >/opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh
+${scripts.install_sh}
+INSTALL_${fuzzer_key}
+
+cat <<'RUN_${fuzzer_key}' >/opt/scfuzzbench/fuzzers/${fuzzer_key}/run.sh
+${scripts.run_sh}
+RUN_${fuzzer_key}
+
+chmod +x /opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh /opt/scfuzzbench/fuzzers/${fuzzer_key}/run.sh
+%{ endfor ~}
+
+chmod +x /opt/scfuzzbench/common.sh /opt/scfuzzbench/queue_worker.sh
 
 source /opt/scfuzzbench/common.sh
 install_shutdown_script
@@ -48,11 +56,24 @@ export ECHIDNA_VERSION="${echidna_version}"
 export MEDUSA_VERSION="${medusa_version}"
 export BITWUZLA_VERSION="${bitwuzla_version}"
 export SCFUZZBENCH_GIT_TOKEN_SSM_PARAMETER="${git_token_ssm_parameter_name}"
+
+export SCFUZZBENCH_QUEUE_MODE="1"
+export SCFUZZBENCH_QUEUE_IDLE_POLLS="${queue_idle_polls}"
+export SCFUZZBENCH_QUEUE_EMPTY_SLEEP_SECONDS="${queue_empty_sleep_seconds}"
+export SCFUZZBENCH_SHARD_MAX_ATTEMPTS="${shard_max_attempts}"
+export SCFUZZBENCH_SHARD_RETRY_BASE_SECONDS="${shard_retry_base_seconds}"
+export SCFUZZBENCH_SHARD_RETRY_MAX_SECONDS="${shard_retry_max_seconds}"
+export SCFUZZBENCH_RUNNING_STALE_SECONDS="${running_stale_seconds}"
+export SCFUZZBENCH_LOCK_NAME="${control_lock_name}"
+export SCFUZZBENCH_LOCK_OBJECT_KEY="${control_lock_object_key}"
+export SCFUZZBENCH_LOCK_LEASE_SECONDS="${control_lock_lease_seconds}"
+export SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS="${control_lock_heartbeat_seconds}"
+export SCFUZZBENCH_MAX_PARALLEL_EFFECTIVE="${max_parallel_effective}"
+
 %{ for key, value in fuzzer_env ~}
 export ${key}="${value}"
 %{ endfor ~}
 
-bash /opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh
-bash /opt/scfuzzbench/fuzzers/${fuzzer_key}/run.sh || true
+bash /opt/scfuzzbench/queue_worker.sh || true
 
 touch /opt/scfuzzbench/.bootstrapped

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -40,6 +40,12 @@ variable "instances_per_fuzzer" {
   default     = 10
 }
 
+variable "max_parallel_instances" {
+  type        = number
+  description = "Maximum concurrent worker instances. Set 0 to use all requested shards."
+  default     = 0
+}
+
 variable "timeout_hours" {
   type        = number
   description = "Timeout for each fuzzer run in hours."
@@ -153,6 +159,60 @@ variable "run_id" {
   type        = string
   description = "Run identifier (defaults to unix timestamp at apply time)."
   default     = ""
+}
+
+variable "control_lock_name" {
+  type        = string
+  description = "S3 lock key used to enforce a single active benchmark run."
+  default     = "benchmark-global-lock"
+}
+
+variable "control_lock_lease_seconds" {
+  type        = number
+  description = "Lease duration for the global run lock in S3. Queue workers renew this lease while the run is active."
+  default     = 7200
+}
+
+variable "control_lock_heartbeat_seconds" {
+  type        = number
+  description = "Heartbeat interval used by queue workers to extend the global run lock lease."
+  default     = 120
+}
+
+variable "queue_idle_polls" {
+  type        = number
+  description = "Number of consecutive empty polls before workers consider the shard queue drained."
+  default     = 3
+}
+
+variable "queue_empty_sleep_seconds" {
+  type        = number
+  description = "Sleep interval in seconds between empty queue polls."
+  default     = 10
+}
+
+variable "shard_max_attempts" {
+  type        = number
+  description = "Maximum retry attempts per shard before terminal failure."
+  default     = 5
+}
+
+variable "shard_retry_base_seconds" {
+  type        = number
+  description = "Base retry delay in seconds for exponential shard retries."
+  default     = 30
+}
+
+variable "shard_retry_max_seconds" {
+  type        = number
+  description = "Maximum retry delay in seconds for exponential shard retries."
+  default     = 300
+}
+
+variable "running_stale_seconds" {
+  type        = number
+  description = "How long a shard can stay in running state without heartbeat before it is reclaimed for retry."
+  default     = 900
 }
 
 variable "tags" {

--- a/scripts/benchmark_lock.py
+++ b/scripts/benchmark_lock.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class AwsError(RuntimeError):
+    pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def now_epoch() -> int:
+    return int(time.time())
+
+
+def aws(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(["aws", *args], text=True, capture_output=True)
+    if check and proc.returncode != 0:
+        raise AwsError((proc.stderr or proc.stdout).strip() or f"aws {' '.join(args)} failed")
+    return proc
+
+
+def emit_output(key: str, value: str) -> None:
+    out_path = os.environ.get("GITHUB_OUTPUT", "").strip()
+    if out_path:
+        with open(out_path, "a", encoding="utf-8") as fh:
+            fh.write(f"{key}={value}\n")
+    else:
+        print(f"{key}={value}")
+
+
+def safe_token(raw: object, fallback: str) -> str:
+    token = re.sub(r"[^A-Za-z0-9._-]", "-", str(raw or "").strip())
+    token = token.strip("-")
+    return token or fallback
+
+
+def s3_put_json(bucket: str, key: str, payload: dict) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8") as tmp:
+        tmp.write(json.dumps(payload, separators=(",", ":")))
+        tmp.flush()
+        aws(
+            [
+                "s3api",
+                "put-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--content-type",
+                "application/json",
+                "--body",
+                tmp.name,
+            ]
+        )
+
+
+def s3_get_json(bucket: str, key: str) -> dict | None:
+    with tempfile.NamedTemporaryFile("w+b") as tmp:
+        proc = aws(
+            [
+                "s3api",
+                "get-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                tmp.name,
+                "--output",
+                "json",
+            ],
+            check=False,
+        )
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout).strip()
+            if "NoSuchKey" in err or "Not Found" in err or "status code: 404" in err:
+                return None
+            raise AwsError(err or f"Failed to read s3://{bucket}/{key}")
+        try:
+            return json.loads(Path(tmp.name).read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+
+def s3_delete_object(bucket: str, key: str) -> None:
+    aws(["s3api", "delete-object", "--bucket", bucket, "--key", key], check=False)
+
+
+def s3_list_keys(bucket: str, prefix: str) -> list[str]:
+    keys: list[str] = []
+    token: str | None = None
+    while True:
+        args = ["s3api", "list-objects-v2", "--bucket", bucket, "--prefix", prefix, "--output", "json"]
+        if token:
+            args.extend(["--continuation-token", token])
+        payload = json.loads(aws(args).stdout or "{}")
+        for item in payload.get("Contents", []):
+            key = str(item.get("Key", "")).strip()
+            if key:
+                keys.append(key)
+        if not payload.get("IsTruncated"):
+            break
+        token = payload.get("NextContinuationToken")
+        if not token:
+            break
+    return keys
+
+
+def lock_root(lock_name: str) -> str:
+    return f"runs/control/locks/{lock_name}"
+
+
+def lock_active_key(lock_name: str) -> str:
+    return f"{lock_root(lock_name)}/active.json"
+
+
+def lock_claim_prefix(lock_name: str) -> str:
+    return f"{lock_root(lock_name)}/claims/"
+
+
+def claim_epoch_from_key(key: str) -> int:
+    match = re.search(r"/claims/(\d+)-", key)
+    if not match:
+        return 0
+    try:
+        return int(match.group(1))
+    except Exception:
+        return 0
+
+
+def lock_owner(active: dict | None) -> str:
+    if not isinstance(active, dict):
+        return ""
+    return str(active.get("owner_run_id", "") or "").strip()
+
+
+def lock_expires_epoch(active: dict | None) -> int:
+    if not isinstance(active, dict):
+        return 0
+    try:
+        return int(active.get("expires_at_epoch", 0))
+    except Exception:
+        return 0
+
+
+def is_lock_active(active: dict | None, now: int) -> bool:
+    return bool(lock_owner(active)) and lock_expires_epoch(active) > now
+
+
+def backoff_seconds(attempt: int, max_backoff_seconds: int) -> int:
+    base = min(max_backoff_seconds, max(3, 2 ** min(attempt, 6)))
+    return min(max_backoff_seconds, base + random.randint(0, 3))
+
+
+def create_claim(
+    *,
+    bucket: str,
+    lock_name: str,
+    owner_run_id: str,
+    workflow_run_id: str,
+    lease_seconds: int,
+) -> str:
+    ts_ms = int(time.time() * 1000)
+    owner_token = safe_token(owner_run_id, "run")
+    nonce = f"{random.getrandbits(32):08x}"
+    key = f"{lock_claim_prefix(lock_name)}{ts_ms}-{owner_token}-{nonce}.json"
+    payload = {
+        "lock_name": lock_name,
+        "owner_run_id": owner_run_id,
+        "workflow_run_id": workflow_run_id,
+        "lease_seconds": lease_seconds,
+        "created_at": now_iso(),
+        "created_epoch": now_epoch(),
+    }
+    s3_put_json(bucket, key, payload)
+    return key
+
+
+def prune_stale_claims(bucket: str, claim_keys: list[str], stale_after_seconds: int) -> list[str]:
+    now_ms = int(time.time() * 1000)
+    keep: list[str] = []
+    for key in sorted(claim_keys):
+        claim_ms = claim_epoch_from_key(key)
+        if claim_ms <= 0:
+            keep.append(key)
+            continue
+        age_seconds = (now_ms - claim_ms) // 1000
+        if age_seconds > stale_after_seconds:
+            s3_delete_object(bucket, key)
+            continue
+        keep.append(key)
+    return keep
+
+
+def acquire_lock(
+    *,
+    bucket: str,
+    lock_name: str,
+    owner_run_id: str,
+    workflow_run_id: str,
+    lease_seconds: int,
+    max_backoff_seconds: int,
+    wait_timeout_seconds: int,
+) -> None:
+    if lease_seconds < 300:
+        raise ValueError(f"Invalid lease_seconds: {lease_seconds} (expected >= 300)")
+    if max_backoff_seconds < 5:
+        raise ValueError(f"Invalid max_backoff_seconds: {max_backoff_seconds} (expected >= 5)")
+    if wait_timeout_seconds < 0:
+        raise ValueError(f"Invalid wait_timeout_seconds: {wait_timeout_seconds} (expected >= 0)")
+
+    deadline = now_epoch() + wait_timeout_seconds if wait_timeout_seconds > 0 else None
+    claim_key = create_claim(
+        bucket=bucket,
+        lock_name=lock_name,
+        owner_run_id=owner_run_id,
+        workflow_run_id=workflow_run_id,
+        lease_seconds=lease_seconds,
+    )
+
+    active_key = lock_active_key(lock_name)
+    stale_claim_after = max(lease_seconds * 2, 1200)
+    attempts = 0
+
+    while True:
+        now = now_epoch()
+        if deadline is not None and now >= deadline:
+            raise TimeoutError(
+                f"Timed out waiting for global lock after {wait_timeout_seconds}s. "
+                "Set lock acquire timeout to 0 for unbounded wait."
+            )
+
+        active = s3_get_json(bucket, active_key)
+        if is_lock_active(active, now) and lock_owner(active) != owner_run_id:
+            holder = lock_owner(active) or "unknown"
+            remaining = lock_expires_epoch(active) - now
+            if remaining < 0:
+                remaining = 0
+            attempts += 1
+            delay = backoff_seconds(attempts, max_backoff_seconds)
+            print(
+                f"Global lock busy (owner_run_id={holder}, remaining={remaining}s); "
+                f"retrying in {delay}s (attempt {attempts}).",
+                flush=True,
+            )
+            time.sleep(delay)
+            continue
+
+        claims = s3_list_keys(bucket, lock_claim_prefix(lock_name))
+        claims = prune_stale_claims(bucket, claims, stale_claim_after)
+        if claim_key not in claims:
+            claim_key = create_claim(
+                bucket=bucket,
+                lock_name=lock_name,
+                owner_run_id=owner_run_id,
+                workflow_run_id=workflow_run_id,
+                lease_seconds=lease_seconds,
+            )
+            claims.append(claim_key)
+
+        claims.sort()
+        if not claims or claims[0] != claim_key:
+            attempts += 1
+            delay = backoff_seconds(attempts, max_backoff_seconds)
+            time.sleep(delay)
+            continue
+
+        acquired_at = now_iso()
+        active_payload = {
+            "lock_name": lock_name,
+            "owner_run_id": owner_run_id,
+            "workflow_run_id": workflow_run_id,
+            "claim_key": claim_key,
+            "acquired_at": acquired_at,
+            "updated_at": acquired_at,
+            "expires_at_epoch": now + lease_seconds,
+            "lease_seconds": lease_seconds,
+        }
+        s3_put_json(bucket, active_key, active_payload)
+        time.sleep(1)
+
+        confirmed = s3_get_json(bucket, active_key)
+        if (
+            isinstance(confirmed, dict)
+            and lock_owner(confirmed) == owner_run_id
+            and str(confirmed.get("claim_key", "")) == claim_key
+            and lock_expires_epoch(confirmed) > now_epoch()
+        ):
+            emit_output("lock_acquired", "true")
+            emit_output("lock_lease_seconds", str(lease_seconds))
+            emit_output("lock_attempts", str(max(1, attempts + 1)))
+            emit_output("lock_object_key", active_key)
+            return
+
+        attempts += 1
+        delay = backoff_seconds(attempts, max_backoff_seconds)
+        time.sleep(delay)
+
+
+def renew_lock(*, bucket: str, lock_name: str, owner_run_id: str, lease_seconds: int) -> None:
+    if lease_seconds < 300:
+        raise ValueError(f"Invalid lease_seconds: {lease_seconds} (expected >= 300)")
+
+    active_key = lock_active_key(lock_name)
+    active = s3_get_json(bucket, active_key)
+    if not isinstance(active, dict):
+        raise AwsError("lock active object not found")
+    if lock_owner(active) != owner_run_id:
+        raise AwsError("lock is held by a different owner")
+
+    now = now_epoch()
+    updated = dict(active)
+    updated["updated_at"] = now_iso()
+    updated["expires_at_epoch"] = now + lease_seconds
+    updated["lease_seconds"] = lease_seconds
+
+    s3_put_json(bucket, active_key, updated)
+    confirmed = s3_get_json(bucket, active_key)
+    if not isinstance(confirmed, dict) or lock_owner(confirmed) != owner_run_id:
+        raise AwsError("lock renew verification failed")
+
+    emit_output("lock_renewed", "true")
+    emit_output("lock_lease_seconds", str(lease_seconds))
+
+
+def release_lock(*, bucket: str, lock_name: str, owner_run_id: str) -> None:
+    active_key = lock_active_key(lock_name)
+    active = s3_get_json(bucket, active_key)
+    released = False
+
+    if isinstance(active, dict) and lock_owner(active) == owner_run_id:
+        s3_delete_object(bucket, active_key)
+        released = True
+
+    owner_token = safe_token(owner_run_id, "run")
+    for key in s3_list_keys(bucket, lock_claim_prefix(lock_name)):
+        if f"-{owner_token}-" in key:
+            s3_delete_object(bucket, key)
+
+    emit_output("lock_released", "true" if released else "false")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Global benchmark lock helpers using S3 lease objects.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    acquire = sub.add_parser("acquire")
+    acquire.add_argument("--bucket", required=True)
+    acquire.add_argument("--lock-name", required=True)
+    acquire.add_argument("--owner-run-id", required=True)
+    acquire.add_argument("--workflow-run-id", required=True)
+    acquire.add_argument("--lease-seconds", type=int, required=True)
+    acquire.add_argument("--max-backoff-seconds", type=int, default=120)
+    acquire.add_argument("--wait-timeout-seconds", type=int, default=0)
+
+    renew = sub.add_parser("renew")
+    renew.add_argument("--bucket", required=True)
+    renew.add_argument("--lock-name", required=True)
+    renew.add_argument("--owner-run-id", required=True)
+    renew.add_argument("--lease-seconds", type=int, required=True)
+
+    release = sub.add_parser("release")
+    release.add_argument("--bucket", required=True)
+    release.add_argument("--lock-name", required=True)
+    release.add_argument("--owner-run-id", required=True)
+
+    args = parser.parse_args()
+
+    if args.cmd == "acquire":
+        acquire_lock(
+            bucket=args.bucket,
+            lock_name=args.lock_name,
+            owner_run_id=args.owner_run_id,
+            workflow_run_id=args.workflow_run_id,
+            lease_seconds=args.lease_seconds,
+            max_backoff_seconds=args.max_backoff_seconds,
+            wait_timeout_seconds=args.wait_timeout_seconds,
+        )
+        return 0
+
+    if args.cmd == "renew":
+        renew_lock(
+            bucket=args.bucket,
+            lock_name=args.lock_name,
+            owner_run_id=args.owner_run_id,
+            lease_seconds=args.lease_seconds,
+        )
+        return 0
+
+    if args.cmd == "release":
+        release_lock(
+            bucket=args.bucket,
+            lock_name=args.lock_name,
+            owner_run_id=args.owner_run_id,
+        )
+        return 0
+
+    raise SystemExit(f"Unknown command: {args.cmd}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/queue_init_run.py
+++ b/scripts/queue_init_run.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+TERMINAL_SHARD_STATUSES = {"succeeded", "failed", "timed_out"}
+TRACKED_SHARD_STATUSES = {"queued", "running", "retrying", *TERMINAL_SHARD_STATUSES}
+
+
+class AwsError(RuntimeError):
+    pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def now_epoch() -> int:
+    return int(time.time())
+
+
+def aws(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(["aws", *args], text=True, capture_output=True)
+    if check and proc.returncode != 0:
+        raise AwsError((proc.stderr or proc.stdout).strip() or f"aws {' '.join(args)} failed")
+    return proc
+
+
+def s3_get_json(bucket: str, key: str) -> tuple[dict | None, str | None]:
+    with tempfile.NamedTemporaryFile("w+b") as tmp:
+        proc = aws(
+            [
+                "s3api",
+                "get-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                tmp.name,
+                "--output",
+                "json",
+            ],
+            check=False,
+        )
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout).strip()
+            if "NoSuchKey" in err or "Not Found" in err or "status code: 404" in err:
+                return None, None
+            raise AwsError(err or f"Failed to read s3://{bucket}/{key}")
+
+        metadata = json.loads(proc.stdout or "{}")
+        etag = str(metadata.get("ETag", "") or "").strip().strip('"')
+        try:
+            raw = Path(tmp.name).read_text(encoding="utf-8")
+            payload = json.loads(raw)
+            if not isinstance(payload, dict):
+                return None, etag
+            return payload, etag or None
+        except Exception:
+            return None, etag or None
+
+
+def s3_put_json(bucket: str, key: str, payload: dict) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8") as tmp:
+        tmp.write(json.dumps(payload, separators=(",", ":")))
+        tmp.flush()
+        aws(
+            [
+                "s3api",
+                "put-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--content-type",
+                "application/json",
+                "--body",
+                tmp.name,
+            ]
+        )
+
+
+def safe_token(raw: object, fallback: str) -> str:
+    token = re.sub(r"[^A-Za-z0-9._-]", "-", str(raw or "").strip())
+    token = token.strip("-")
+    return token or fallback
+
+
+def write_event(
+    *,
+    bucket: str,
+    events_prefix: str,
+    run_id: str,
+    benchmark_uuid: str,
+    shard_key: str,
+    status: str,
+    instance_id: str,
+    attempt: int,
+    message: str = "",
+) -> str:
+    ts_ms = int(time.time() * 1000)
+    safe_instance = safe_token(instance_id, "unknown")
+    safe_shard = safe_token(shard_key, "run")
+    safe_status = safe_token(status, "event")
+    key = f"{events_prefix}/{ts_ms}-{safe_instance}-{safe_shard}-{safe_status}.json"
+    payload = {
+        "ts_epoch_ms": ts_ms,
+        "ts": now_iso(),
+        "run_id": run_id,
+        "benchmark_uuid": benchmark_uuid,
+        "instance_id": instance_id,
+        "shard_key": shard_key,
+        "status": status,
+        "attempt": int(attempt),
+    }
+    if message:
+        payload["message"] = message
+    s3_put_json(bucket, key, payload)
+    return key
+
+
+def normalize_shard(value: object) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError("each shard entry must be an object")
+
+    shard_key = str(value.get("shard_key", "")).strip()
+    fuzzer_key = str(value.get("fuzzer_key", "")).strip()
+    run_index_raw = value.get("run_index", "")
+
+    if not shard_key or not re.match(r"^[a-z0-9][a-z0-9-]{0,63}$", shard_key):
+        raise ValueError(f"invalid shard_key: {shard_key!r}")
+    if not fuzzer_key or not re.match(r"^[a-z0-9][a-z0-9-]{0,63}$", fuzzer_key):
+        raise ValueError(f"invalid fuzzer_key for shard {shard_key}: {fuzzer_key!r}")
+
+    try:
+        run_index = int(run_index_raw)
+    except Exception as exc:
+        raise ValueError(f"invalid run_index for shard {shard_key}: {run_index_raw!r}") from exc
+    if run_index < 0:
+        raise ValueError(f"run_index must be >= 0 for shard {shard_key}")
+
+    return {
+        "shard_key": shard_key,
+        "fuzzer_key": fuzzer_key,
+        "run_index": run_index,
+    }
+
+
+def shard_counts(shards: list[dict]) -> dict[str, int]:
+    counts = {status: 0 for status in TRACKED_SHARD_STATUSES}
+    counts["unknown"] = 0
+    for shard in shards:
+        status = str(shard.get("status", "")).strip().lower()
+        if status in counts:
+            counts[status] += 1
+        else:
+            counts["unknown"] += 1
+    return counts
+
+
+def run_status_from_counts(counts: dict[str, int]) -> str:
+    active = counts.get("queued", 0) + counts.get("running", 0) + counts.get("retrying", 0)
+    if active > 0:
+        return "running"
+    if counts.get("failed", 0) > 0 or counts.get("timed_out", 0) > 0:
+        return "failed"
+    return "completed"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Initialize S3-only queue state for a benchmark run.")
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--benchmark-uuid", required=True)
+    parser.add_argument("--max-parallel-effective", required=True, type=int)
+    parser.add_argument("--shard-max-attempts", type=int, default=5)
+    parser.add_argument("--shards-json", required=True, type=Path)
+    parser.add_argument("--summary-path", required=False, type=Path)
+    args = parser.parse_args()
+
+    if args.max_parallel_effective < 1:
+        raise SystemExit("--max-parallel-effective must be >= 1")
+    if args.shard_max_attempts < 1:
+        raise SystemExit("--shard-max-attempts must be >= 1")
+
+    raw_shards = json.loads(args.shards_json.read_text(encoding="utf-8"))
+    if not isinstance(raw_shards, list) or not raw_shards:
+        raise SystemExit("--shards-json must contain a non-empty JSON array")
+
+    shards = [normalize_shard(entry) for entry in raw_shards]
+
+    run_prefix = f"runs/{args.run_id}/{args.benchmark_uuid}"
+    shard_prefix = f"{run_prefix}/queue/shards"
+    events_prefix = f"{run_prefix}/status/events"
+    run_status_key = f"{run_prefix}/status/run.json"
+
+    preserved_existing = 0
+    created_queued = 0
+    initialized_shards: list[dict] = []
+
+    for shard in shards:
+        shard_key = shard["shard_key"]
+        key = f"{shard_prefix}/{shard_key}.json"
+        existing, _ = s3_get_json(args.bucket, key)
+        if isinstance(existing, dict) and str(existing.get("status", "")).strip().lower() in TRACKED_SHARD_STATUSES:
+            initialized_shards.append(existing)
+            preserved_existing += 1
+            continue
+
+        created_at = now_iso()
+        state = {
+            "run_id": args.run_id,
+            "benchmark_uuid": args.benchmark_uuid,
+            "queue_backend": "s3",
+            "shard_key": shard_key,
+            "fuzzer_key": shard["fuzzer_key"],
+            "run_index": shard["run_index"],
+            "status": "queued",
+            "attempt": 0,
+            "max_attempts": args.shard_max_attempts,
+            "created_at": created_at,
+            "updated_at": created_at,
+            "next_attempt_at": created_at,
+        }
+        s3_put_json(args.bucket, key, state)
+        initialized_shards.append(state)
+        created_queued += 1
+        write_event(
+            bucket=args.bucket,
+            events_prefix=events_prefix,
+            run_id=args.run_id,
+            benchmark_uuid=args.benchmark_uuid,
+            shard_key=shard_key,
+            status="queued",
+            instance_id="bootstrap",
+            attempt=0,
+            message="initialized by queue_init_run.py",
+        )
+
+    counts = shard_counts(initialized_shards)
+    status = run_status_from_counts(counts)
+    status_payload = {
+        "run_id": args.run_id,
+        "benchmark_uuid": args.benchmark_uuid,
+        "queue_backend": "s3",
+        "status": status,
+        "requested_shards": len(shards),
+        "max_parallel_instances": args.max_parallel_effective,
+        "shard_max_attempts": args.shard_max_attempts,
+        "queued_count": counts.get("queued", 0),
+        "running_count": counts.get("running", 0),
+        "retrying_count": counts.get("retrying", 0),
+        "succeeded_count": counts.get("succeeded", 0),
+        "failed_count": counts.get("failed", 0),
+        "timed_out_count": counts.get("timed_out", 0),
+        "unknown_count": counts.get("unknown", 0),
+        "updated_at": now_iso(),
+        "updated_epoch": now_epoch(),
+    }
+    if status in {"completed", "failed"}:
+        status_payload["completed_at"] = now_iso()
+
+    s3_put_json(args.bucket, run_status_key, status_payload)
+    write_event(
+        bucket=args.bucket,
+        events_prefix=events_prefix,
+        run_id=args.run_id,
+        benchmark_uuid=args.benchmark_uuid,
+        shard_key="run",
+        status=status,
+        instance_id="bootstrap",
+        attempt=0,
+        message="run status initialized",
+    )
+
+    summary = {
+        "run_id": args.run_id,
+        "benchmark_uuid": args.benchmark_uuid,
+        "requested_shards": len(shards),
+        "created_queued": created_queued,
+        "preserved_existing": preserved_existing,
+        "run_status": status,
+        "counts": counts,
+        "run_status_key": run_status_key,
+    }
+
+    if args.summary_path is not None:
+        args.summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(summary, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_completion.py
+++ b/scripts/run_completion.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+TERMINAL_RUN_STATUSES = {"completed", "failed"}
+
+
+def as_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def normalize_status(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def is_terminal_run_status(value: object) -> bool:
+    return normalize_status(value) in TERMINAL_RUN_STATUSES
+
+
+def is_queue_mode_run(manifest: dict) -> bool:
+    return as_bool(manifest.get("queue_mode", False))
+
+
+def timeout_hours_from_manifest(manifest: dict, default: float = 24.0) -> float:
+    try:
+        return float(manifest.get("timeout_hours", default))
+    except Exception:
+        return default
+
+
+def is_run_complete(
+    manifest: dict,
+    *,
+    run_id: str,
+    now_epoch: int,
+    grace_seconds: int,
+    queue_status: object | None = None,
+) -> bool:
+    if is_queue_mode_run(manifest):
+        return is_terminal_run_status(queue_status)
+
+    try:
+        run_start = int(run_id)
+    except Exception:
+        return False
+    timeout_hours = timeout_hours_from_manifest(manifest)
+    deadline = run_start + int(timeout_hours * 3600) + int(grace_seconds)
+    return now_epoch >= deadline


### PR DESCRIPTION
## Summary
- Switch benchmark queued execution to an S3-only control plane (supersedes SQS/DynamoDB flow from #32/#33)
- Keep explicit worker parallelism via `max_parallel_instances` and fixed worker pool behavior
- Implement S3 lease-based global lock (acquire/renew/release) and S3-only queue bootstrap/worker lifecycle
- Update release/docs completion logic to use terminal `runs/<run_id>/<benchmark_uuid>/status/run.json` for queue-mode runs

## What changed
- Terraform:
  - Removed SQS and DynamoDB queue/state resources, variables, outputs, and IAM permissions for those services
  - Added/kept S3 queue+status+lock settings and `running_stale_seconds`
  - Updated user-data env exports for S3 queue worker mode
- Scripts:
  - Added `scripts/benchmark_lock.py` for S3 lease lock acquire/renew/release
  - Added `scripts/queue_init_run.py` for S3 shard/run status bootstrap
  - Added shared queue completion helper `scripts/run_completion.py`
  - Updated `scripts/generate_docs_site.py` to use S3 queue status completion checks
- Worker runtime:
  - Replaced queue worker logic with S3 claim/retry/terminalization flow in `fuzzers/_shared/queue_worker.sh`
  - Persist shard/run/worker/events/dlq state directly in S3
  - Added lock heartbeat fail-closed handling and stale-running reclaim logic
- Workflows/UI/docs:
  - Added `max_parallel_instances` in request template, request workflow parsing, benchmark workflow inputs, and StartBenchmark UI
  - Removed quota auto-discovery behavior and use explicit parallelism in benchmark workflow
  - Updated release/docs completion checks and docs/README paths for queue-mode run status

## Validation
- `make terraform-fmt`
- `make terraform-validate`
- `actionlint .github/workflows/benchmark-run.yml .github/workflows/benchmark-release.yml .github/workflows/benchmark-request.yml`
- `python3 -m py_compile scripts/benchmark_lock.py scripts/queue_init_run.py scripts/run_completion.py scripts/generate_docs_site.py`
- `bash -n fuzzers/_shared/queue_worker.sh fuzzers/_shared/common.sh infrastructure/user_data.sh.tftpl`

Closes #37.
