### PR TITLE
Implement S3-only queued benchmark orchestration

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark-request.md
+++ b/.github/ISSUE_TEMPLATE/benchmark-request.md
@@ -14,7 +14,7 @@ Notes:
 - Step `01` (`benchmark/01-pending`) is applied by this template at issue creation.
 - Step `02` (`benchmark/02-validated`) is applied by the bot after JSON validation passes.
 - Step `03` (`benchmark/03-approved`) is applied manually by a maintainer to start the run.
-- Limits: `instances_per_fuzzer` must be in `[1, 20]`, `timeout_hours` must be in `[0.25, 72]`.
+- Limits: `instances_per_fuzzer` must be in `[1, 20]`, `max_parallel_instances` must be in `[1, 50]`, `timeout_hours` must be in `[0.25, 72]`.
 
 ```json
 {
@@ -23,6 +23,7 @@ Notes:
   "benchmark_type": "property",
   "instance_type": "c6a.4xlarge",
   "instances_per_fuzzer": 4,
+  "max_parallel_instances": 3,
   "timeout_hours": 1,
   "fuzzers": ["echidna", "medusa", "foundry"],
   "foundry_version": "",

--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -35,6 +35,21 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION != '' && secrets.AWS_REGION || 'us-east-1' }}
       SCFUZZBENCH_BUCKET: ${{ secrets.SCFUZZBENCH_BUCKET }}
     steps:
+      - name: Checkout (tarball)
+        timeout-minutes: 5
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          url="https://codeload.github.com/${REPO}/tar.gz/${SHA}"
+          curl -fsSL "${url}" -o repo.tar.gz
+          topdir="$(tar -tzf repo.tar.gz | sed -n '1p' | cut -d/ -f1)"
+          tar -xzf repo.tar.gz
+          shopt -s dotglob
+          mv "${topdir}"/* .
+          rm -rf "${topdir}" repo.tar.gz
+
       - name: Ensure AWS credentials are configured
         run: |
           if [ -z "${{ secrets.AWS_ACCESS_KEY_ID }}" ] || [ -z "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]; then
@@ -91,70 +106,24 @@ jobs:
           fi
 
           matrix=$(python3 - <<'PY'
-          import json
           import os
           import subprocess
-          import time
 
           bucket = os.environ["SCFUZZBENCH_BUCKET"]
-          grace = int(os.environ.get("GRACE_SECONDS", "3600"))
-          now = int(time.time())
-
-          def aws(*args: str) -> str:
-              return subprocess.check_output(["aws", *args], text=True)
-
-          def list_prefixes(prefix: str) -> list[str]:
-              data = json.loads(
-                  aws(
-                      "s3api",
-                      "list-objects-v2",
-                      "--bucket",
-                      bucket,
-                      "--prefix",
-                      prefix,
-                      "--delimiter",
-                      "/",
-                      "--output",
-                      "json",
-                  )
-              )
-              return [entry["Prefix"] for entry in data.get("CommonPrefixes", [])]
-
-          runs: list[dict] = []
-          for run_prefix in list_prefixes("logs/"):
-              parts = run_prefix.strip("/").split("/")
-              if len(parts) < 2:
-                  continue
-              run_id = parts[1]
-              for bench_prefix in list_prefixes(f"logs/{run_id}/"):
-                  bench_parts = bench_prefix.strip("/").split("/")
-                  if len(bench_parts) < 3:
-                      continue
-                  benchmark_uuid = bench_parts[2]
-                  manifest_key = f"logs/{run_id}/{benchmark_uuid}/manifest.json"
-                  try:
-                      manifest_raw = aws("s3", "cp", f"s3://{bucket}/{manifest_key}", "-")
-                      manifest = json.loads(manifest_raw)
-                  except Exception:
-                      continue
-                  try:
-                      timeout_hours = float(manifest.get("timeout_hours", 24))
-                  except Exception:
-                      timeout_hours = 24.0
-                  try:
-                      run_start = int(run_id)
-                  except ValueError:
-                      continue
-                  if now >= run_start + int(timeout_hours * 3600) + grace:
-                      runs.append(
-                          {
-                              "benchmark_uuid": benchmark_uuid,
-                              "run_id": run_id,
-                              "timeout_hours": timeout_hours,
-                          }
-                      )
-
-          print(json.dumps({"include": runs}, separators=(",", ":")))
+          grace = os.environ.get("GRACE_SECONDS", "3600")
+          out = subprocess.check_output(
+              [
+                  "python3",
+                  "scripts/run_completion.py",
+                  "discover",
+                  "--bucket",
+                  bucket,
+                  "--grace-seconds",
+                  grace,
+              ],
+              text=True,
+          )
+          print(out.strip())
           PY
           )
 

--- a/.github/workflows/benchmark-request.yml
+++ b/.github/workflows/benchmark-request.yml
@@ -23,6 +23,7 @@ jobs:
       benchmark_type: ${{ steps.prepare.outputs.benchmark_type }}
       instance_type: ${{ steps.prepare.outputs.instance_type }}
       instances_per_fuzzer: ${{ steps.prepare.outputs.instances_per_fuzzer }}
+      max_parallel_instances: ${{ steps.prepare.outputs.max_parallel_instances }}
       timeout_hours: ${{ steps.prepare.outputs.timeout_hours }}
       fuzzers_json: ${{ steps.prepare.outputs.fuzzers_json }}
       foundry_version: ${{ steps.prepare.outputs.foundry_version }}
@@ -246,6 +247,8 @@ jobs:
 
             const inst = mustNumber(payload, "instances_per_fuzzer", { required: true, min: 1, max: 20, integer: true });
             if (!inst.ok) errors.push(inst.message);
+            const maxParallel = mustNumber(payload, "max_parallel_instances", { required: false, min: 1, max: 50, integer: true });
+            if (!maxParallel.ok) errors.push(maxParallel.message);
 
             const hours = mustNumber(payload, "timeout_hours", { required: true, min: 0.25, max: 72, integer: false });
             if (!hours.ok) errors.push(hours.message);
@@ -279,6 +282,12 @@ jobs:
               }
             }
             const fuzzersJson = JSON.stringify(fuzzers);
+            const maxParallelValue = maxParallel.ok && maxParallel.value !== null
+              ? maxParallel.value
+              : Math.min(3, inst.ok ? inst.value : 3);
+            if (inst.ok && maxParallelValue > (inst.value * fuzzers.length)) {
+              errors.push(`max_parallel_instances must be <= total requested shards (${inst.value * fuzzers.length})`);
+            }
 
             const githubRepoUrlRe = /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?\/?$/;
             if (url.ok) {
@@ -401,6 +410,7 @@ jobs:
                   `- Type: \`${bt}\``,
                   `- Instance type: \`${itype.value}\``,
                   `- Instances per fuzzer: \`${inst.value}\``,
+                  `- Max parallel instances: \`${maxParallelValue}\``,
                   `- Timeout hours: \`${hours.value}\``,
                   `- Fuzzers: \`${fuzzersJson}\``,
                   "",
@@ -425,6 +435,7 @@ jobs:
                   `- Type: \`${bt}\``,
                   `- Instance type: \`${itype.value}\``,
                   `- Instances per fuzzer: \`${inst.value}\``,
+                  `- Max parallel instances: \`${maxParallelValue}\``,
                   `- Timeout hours: \`${hours.value}\``,
                   `- Fuzzers: \`${fuzzersJson}\``,
                 ].join("\n")
@@ -437,6 +448,7 @@ jobs:
               core.setOutput("benchmark_type", bt);
               core.setOutput("instance_type", itype.value);
               core.setOutput("instances_per_fuzzer", String(inst.value));
+              core.setOutput("max_parallel_instances", String(maxParallelValue));
               core.setOutput("timeout_hours", String(hours.value));
               core.setOutput("fuzzers_json", fuzzersJson);
 
@@ -462,6 +474,7 @@ jobs:
       benchmark_type: ${{ needs.prepare.outputs.benchmark_type }}
       instance_type: ${{ needs.prepare.outputs.instance_type }}
       instances_per_fuzzer: ${{ fromJSON(needs.prepare.outputs.instances_per_fuzzer) }}
+      max_parallel_instances: ${{ fromJSON(needs.prepare.outputs.max_parallel_instances) }}
       timeout_hours: ${{ fromJSON(needs.prepare.outputs.timeout_hours) }}
       fuzzers_json: ${{ needs.prepare.outputs.fuzzers_json }}
       foundry_version: ${{ needs.prepare.outputs.foundry_version }}
@@ -560,7 +573,7 @@ jobs:
                 "Docs:",
                 `- ${docsUrl}`,
                 "",
-                "_Note: the docs site only shows **complete** runs (timeout + 1h grace)._",
+                "_Note: the docs site only shows **complete** runs (terminal run status, with legacy timeout fallback)._",
               ].join("\n")
             );
 

--- a/.github/workflows/benchmark-run.yml
+++ b/.github/workflows/benchmark-run.yml
@@ -22,10 +22,15 @@ on:
         required: true
         default: c6a.8xlarge
       instances_per_fuzzer:
-        description: "Number of instances per fuzzer."
+        description: "Number of shards per fuzzer."
         required: true
         type: number
         default: 10
+      max_parallel_instances:
+        description: "Maximum parallel worker instances."
+        required: true
+        type: number
+        default: 3
       timeout_hours:
         description: "Timeout per fuzzer run (hours)."
         required: true
@@ -92,10 +97,15 @@ on:
         type: string
         default: c6a.8xlarge
       instances_per_fuzzer:
-        description: "Number of instances per fuzzer."
+        description: "Number of shards per fuzzer."
         required: false
         type: number
         default: 10
+      max_parallel_instances:
+        description: "Maximum parallel worker instances."
+        required: false
+        type: number
+        default: 3
       timeout_hours:
         description: "Timeout per fuzzer run (hours)."
         required: false
@@ -251,6 +261,7 @@ jobs:
           BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INSTANCE_TYPE: ${{ inputs.instance_type }}
           INSTANCES_PER_FUZZER: ${{ inputs.instances_per_fuzzer }}
+          MAX_PARALLEL_INSTANCES: ${{ inputs.max_parallel_instances }}
           TIMEOUT_HOURS: ${{ inputs.timeout_hours }}
           FUZZERS_JSON: ${{ inputs.fuzzers_json }}
           FOUNDRY_VERSION: ${{ inputs.foundry_version }}
@@ -349,6 +360,10 @@ jobs:
             fail "instances_per_fuzzer must be an integer in [1, 20]"
           fi
 
+          if [[ ! "${MAX_PARALLEL_INSTANCES}" =~ ^[0-9]+$ ]] || (( MAX_PARALLEL_INSTANCES < 1 )) || (( MAX_PARALLEL_INSTANCES > 50 )); then
+            fail "max_parallel_instances must be an integer in [1, 50]"
+          fi
+
           if [[ ! "${TIMEOUT_HOURS}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
             fail "timeout_hours must be a number"
           fi
@@ -382,6 +397,22 @@ jobs:
               if not isinstance(v, str) or not key_re.match(v):
                   raise SystemExit(f"Invalid fuzzer key: {v!r}")
           PY
+
+          fuzzer_count=$(python3 - <<'PY'
+          import json
+          import os
+
+          raw = os.environ.get("FUZZERS_JSON", "").strip()
+          if not raw:
+              raw = '["echidna","medusa","foundry"]'
+          obj = json.loads(raw)
+          print(len(obj))
+          PY
+          )
+          total_shards=$((INSTANCES_PER_FUZZER * fuzzer_count))
+          if (( MAX_PARALLEL_INSTANCES > total_shards )); then
+            fail "max_parallel_instances must be <= total requested shards (${total_shards})"
+          fi
 
           if [[ -n "${GIT_TOKEN_SSM_PARAMETER_NAME}" ]]; then
             require_safe "git_token_ssm_parameter_name" "${GIT_TOKEN_SSM_PARAMETER_NAME}"
@@ -436,6 +467,7 @@ jobs:
           BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INSTANCE_TYPE: ${{ inputs.instance_type }}
           INSTANCES_PER_FUZZER: ${{ inputs.instances_per_fuzzer }}
+          MAX_PARALLEL_INSTANCES: ${{ inputs.max_parallel_instances }}
           TIMEOUT_HOURS: ${{ inputs.timeout_hours }}
           FUZZERS_JSON: ${{ inputs.fuzzers_json }}
           FOUNDRY_VERSION: ${{ inputs.foundry_version }}
@@ -450,10 +482,34 @@ jobs:
         run: |
           set -euo pipefail
           run_id=$(date +%s)
+          lock_owner="gh-${GITHUB_RUN_ID}-${run_id}"
           fuzzers="${FUZZERS_JSON:-}"
           if [[ -z "${fuzzers}" ]]; then
             fuzzers='["echidna","medusa","foundry"]'
           fi
+
+          python3 scripts/s3_lock.py acquire \
+            --bucket "${SCFUZZBENCH_BUCKET}" \
+            --owner "${lock_owner}" \
+            --run-id "${run_id}" \
+            --benchmark-uuid "pending" \
+            --lease-seconds 14400 \
+            --acquire-timeout-seconds 0 \
+            --poll-seconds 10.0 >/tmp/scfuzzbench-lock-acquire.json
+          lock_acquired=1
+
+          cleanup_on_error() {
+            local exit_code=$?
+            trap - EXIT
+            if [[ "${exit_code}" -ne 0 && "${lock_acquired}" -eq 1 ]]; then
+              python3 scripts/s3_lock.py release \
+                --bucket "${SCFUZZBENCH_BUCKET}" \
+                --owner "${lock_owner}" >/dev/null 2>&1 || true
+            fi
+            exit "${exit_code}"
+          }
+          trap cleanup_on_error EXIT
+
           tf_args=(
             -var "aws_region=${AWS_REGION}"
             -var "existing_bucket_name=${SCFUZZBENCH_BUCKET}"
@@ -462,10 +518,13 @@ jobs:
             -var "benchmark_type=${BENCHMARK_TYPE}"
             -var "instance_type=${INSTANCE_TYPE}"
             -var "instances_per_fuzzer=${INSTANCES_PER_FUZZER}"
+            -var "max_parallel_instances=${MAX_PARALLEL_INSTANCES}"
             -var "timeout_hours=${TIMEOUT_HOURS}"
             -var "fuzzers=${fuzzers}"
             -var "run_id=${run_id}"
+            -var "lock_owner=${lock_owner}"
             -var "scfuzzbench_commit=${GITHUB_SHA}"
+            -var "scfuzzbench_repo=${GITHUB_REPOSITORY}"
           )
 
           if [[ -n "${FOUNDRY_VERSION}" ]]; then
@@ -509,7 +568,10 @@ jobs:
           fi
 
           terraform -chdir=infrastructure apply -auto-approve "${tf_args[@]}"
+          lock_acquired=0
+          trap - EXIT
           echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
+          echo "lock_owner=${lock_owner}" >> "${GITHUB_OUTPUT}"
 
       - name: Collect Terraform outputs
         id: tf_outputs
@@ -535,4 +597,6 @@ jobs:
             echo ""
             echo "- Run ID: ${{ steps.tf_outputs.outputs.run_id }}"
             echo "- Benchmark UUID: ${{ steps.tf_outputs.outputs.benchmark_uuid }}"
+            echo "- Shards per fuzzer: ${{ inputs.instances_per_fuzzer }}"
+            echo "- Max parallel instances: ${{ inputs.max_parallel_instances }}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ features:
   - title: Timestamp-first runs
     details: Run IDs are Unix timestamps, so “latest” is always obvious just by listing prefixes.
   - title: Complete runs only
-    details: The site lists only complete runs (timeout plus a 1h grace period) to avoid partial results.
+    details: The site lists only complete runs (terminal run status for queue mode, with legacy timeout fallback).
   - title: Triage-friendly
     details: Complete runs missing analysis stay visible with warnings and raw-artifact links.
 ---

--- a/docs/runs/index.md
+++ b/docs/runs/index.md
@@ -3,7 +3,7 @@
 This page is generated in CI from the S3 run index (`runs/<run_id>/<benchmark_uuid>/manifest.json`).
 
 ::: tip
-Only **complete** runs are shown (timeout + 1h grace).
+Only **complete** runs are shown (terminal run status for queue mode, with legacy timeout + 1h grace fallback).
 
 If you are previewing locally, run the generator first:
 

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -19,11 +19,26 @@ output "ssh_private_key_path" {
 }
 
 output "instance_ids" {
-  description = "Instance IDs by fuzzer and index."
+  description = "Worker instance IDs by worker index."
   value       = { for key, instance in aws_instance.fuzzer : key => instance.id }
 }
 
 output "instance_public_ips" {
-  description = "Public IPs by fuzzer and index."
+  description = "Worker public IPs by worker index."
   value       = { for key, instance in aws_instance.fuzzer : key => instance.public_ip }
+}
+
+output "shard_count" {
+  description = "Total number of queued shards in this run."
+  value       = local.shard_count
+}
+
+output "max_parallel_instances" {
+  description = "Configured parallel worker pool size."
+  value       = var.max_parallel_instances
+}
+
+output "lock_owner" {
+  description = "Owner token used for the run's global S3 lock."
+  value       = local.lock_owner
 }

--- a/infrastructure/user_data.sh.tftpl
+++ b/infrastructure/user_data.sh.tftpl
@@ -9,23 +9,58 @@ fi
 
 systemctl enable --now ssh || systemctl enable --now sshd || true
 
-mkdir -p /opt/scfuzzbench/fuzzers/${fuzzer_key}
+mkdir -p /opt/scfuzzbench/fuzzers /opt/scfuzzbench/scripts
 
-cat <<'SHARED' >/opt/scfuzzbench/common.sh
-${shared_sh}
-SHARED
+bootstrap_repo="${scfuzzbench_repo}"
+bootstrap_ref="${scfuzzbench_commit}"
+if [[ -z "$${bootstrap_ref}" ]]; then
+  bootstrap_ref="main"
+fi
 
-cat <<'INSTALL' >/opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh
-${install_sh}
-INSTALL
+tmp_bootstrap_dir=$(mktemp -d)
+archive_path="$${tmp_bootstrap_dir}/repo.tar.gz"
+archive_url="https://codeload.github.com/$${bootstrap_repo}/tar.gz/$${bootstrap_ref}"
+curl -fsSL "$${archive_url}" -o "$${archive_path}"
 
-cat <<'RUN' >/opt/scfuzzbench/fuzzers/${fuzzer_key}/run.sh
-${run_sh}
-RUN
+topdir="$(tar -tzf "$${archive_path}" | sed -n '1p' | cut -d/ -f1)"
+tar -xzf "$${archive_path}" -C "$${tmp_bootstrap_dir}"
+repo_root="$${tmp_bootstrap_dir}/$${topdir}"
 
-chmod +x /opt/scfuzzbench/common.sh \
-  /opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh \
-  /opt/scfuzzbench/fuzzers/${fuzzer_key}/run.sh
+install -m 0755 "$${repo_root}/fuzzers/_shared/common.sh" /opt/scfuzzbench/common.sh
+install -m 0755 "$${repo_root}/scripts/s3_lock.py" /opt/scfuzzbench/scripts/s3_lock.py
+install -m 0755 "$${repo_root}/scripts/s3_queue_init.py" /opt/scfuzzbench/scripts/s3_queue_init.py
+install -m 0755 "$${repo_root}/scripts/s3_queue_worker.py" /opt/scfuzzbench/scripts/s3_queue_worker.py
+
+export SCFUZZBENCH_SRC_REPO_ROOT="$${repo_root}"
+export SCFUZZBENCH_FUZZER_KEYS_JSON='${fuzzer_keys_json}'
+python3 - <<'PY'
+import json
+import os
+import pathlib
+import shutil
+
+repo_root = pathlib.Path(os.environ["SCFUZZBENCH_SRC_REPO_ROOT"])
+dest_root = pathlib.Path("/opt/scfuzzbench/fuzzers")
+keys = json.loads(os.environ["SCFUZZBENCH_FUZZER_KEYS_JSON"])
+
+if not isinstance(keys, list) or not keys:
+    raise SystemExit("SCFUZZBENCH_FUZZER_KEYS_JSON must be a non-empty list")
+
+for key in keys:
+    if not isinstance(key, str) or not key:
+        raise SystemExit(f"invalid fuzzer key: {key!r}")
+    src_dir = repo_root / "fuzzers" / key
+    if not src_dir.is_dir():
+        raise SystemExit(f"missing fuzzer directory in bootstrap bundle: {src_dir}")
+    out_dir = dest_root / key
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src_dir / "install.sh", out_dir / "install.sh")
+    shutil.copy2(src_dir / "run.sh", out_dir / "run.sh")
+    (out_dir / "install.sh").chmod(0o755)
+    (out_dir / "run.sh").chmod(0o755)
+PY
+
+rm -rf "$${tmp_bootstrap_dir}"
 
 source /opt/scfuzzbench/common.sh
 install_shutdown_script
@@ -41,6 +76,18 @@ export SCFUZZBENCH_TIMEOUT_SECONDS="${timeout_seconds}"
 export SCFUZZBENCH_REPO_URL="${repo_url}"
 export SCFUZZBENCH_COMMIT="${repo_commit}"
 export SCFUZZBENCH_BENCHMARK_TYPE="${benchmark_type}"
+export SCFUZZBENCH_FUZZER_KEYS_JSON='${fuzzer_keys_json}'
+export SCFUZZBENCH_SHARDS_JSON_B64='${shards_json_b64}'
+export SCFUZZBENCH_MAX_PARALLEL_INSTANCES='${max_parallel_instances}'
+export SCFUZZBENCH_SHARD_MAX_ATTEMPTS='${shard_max_attempts}'
+export SCFUZZBENCH_LOCK_OWNER='${lock_owner}'
+export SCFUZZBENCH_LOCK_KEY='${lock_key}'
+export SCFUZZBENCH_LOCK_LEASE_SECONDS='${lock_lease_seconds}'
+export SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS='${lock_heartbeat_seconds}'
+export SCFUZZBENCH_LOCK_ACQUIRE_TIMEOUT_SECONDS='${lock_acquire_timeout_seconds}'
+export SCFUZZBENCH_QUEUE_POLL_SECONDS='${queue_poll_seconds}'
+export SCFUZZBENCH_QUEUE_IDLE_POLLS_BEFORE_EXIT='${queue_idle_polls_before_exit}'
+export SCFUZZBENCH_WORKER_INDEX='${worker_index}'
 export FOUNDRY_VERSION="${foundry_version}"
 export FOUNDRY_GIT_REPO="${foundry_git_repo}"
 export FOUNDRY_GIT_REF="${foundry_git_ref}"
@@ -52,7 +99,16 @@ export SCFUZZBENCH_GIT_TOKEN_SSM_PARAMETER="${git_token_ssm_parameter_name}"
 export ${key}="${value}"
 %{ endfor ~}
 
-bash /opt/scfuzzbench/fuzzers/${fuzzer_key}/install.sh
-bash /opt/scfuzzbench/fuzzers/${fuzzer_key}/run.sh || true
+for fuzzer_key in $(python3 - <<'PY'
+import json
+import os
+for key in json.loads(os.environ["SCFUZZBENCH_FUZZER_KEYS_JSON"]):
+    print(key)
+PY
+); do
+  bash "/opt/scfuzzbench/fuzzers/$${fuzzer_key}/install.sh"
+done
+
+python3 /opt/scfuzzbench/scripts/s3_queue_worker.py
 
 touch /opt/scfuzzbench/.bootstrapped

--- a/scripts/run_completion.py
+++ b/scripts/run_completion.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+RUN_MANIFEST_RE = re.compile(r"^runs/([0-9]+)/([0-9a-f]{32})/manifest\.json$")
+TERMINAL_STATES = {"succeeded", "failed", "timed_out", "completed"}
+
+
+def aws_env(profile: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    if profile:
+        env["AWS_PROFILE"] = profile
+    return env
+
+
+def aws_text(args: list[str], *, profile: str | None) -> str:
+    return subprocess.check_output(["aws", *args], text=True, env=aws_env(profile))
+
+
+def aws_json(args: list[str], *, profile: str | None) -> dict[str, Any]:
+    out = aws_text([*args, "--output", "json"], profile=profile)
+    return json.loads(out) if out.strip() else {}
+
+
+def list_keys(bucket: str, prefix: str, *, profile: str | None) -> list[str]:
+    keys: list[str] = []
+    token: str | None = None
+    while True:
+        cmd = ["s3api", "list-objects-v2", "--bucket", bucket, "--prefix", prefix]
+        if token:
+            cmd += ["--continuation-token", token]
+        data = aws_json(cmd, profile=profile)
+        keys.extend([obj["Key"] for obj in data.get("Contents", [])])
+        if not data.get("IsTruncated"):
+            break
+        token = data.get("NextContinuationToken")
+        if not token:
+            break
+    return keys
+
+
+def s3_json_or_none(bucket: str, key: str, *, profile: str | None) -> dict[str, Any] | None:
+    try:
+        raw = aws_text(["s3", "cp", f"s3://{bucket}/{key}", "-"], profile=profile)
+    except subprocess.CalledProcessError:
+        return None
+    try:
+        value = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(value, dict):
+        return None
+    return value
+
+
+def safe_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+@dataclass(frozen=True)
+class Completion:
+    run_id: str
+    benchmark_uuid: str
+    complete: bool
+    reason: str
+    timeout_hours: float | None
+    queue_mode: bool
+    status_state: str
+    status_terminal: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "run_id": self.run_id,
+            "benchmark_uuid": self.benchmark_uuid,
+            "complete": self.complete,
+            "reason": self.reason,
+            "queue_mode": self.queue_mode,
+            "status_state": self.status_state,
+            "status_terminal": self.status_terminal,
+        }
+        if self.timeout_hours is not None:
+            out["timeout_hours"] = self.timeout_hours
+        return out
+
+
+def check_run_completion(
+    *,
+    bucket: str,
+    run_id: str,
+    benchmark_uuid: str,
+    grace_seconds: int,
+    profile: str | None,
+    now: int | None = None,
+) -> Completion:
+    if now is None:
+        now = int(time.time())
+
+    status_key = f"runs/{run_id}/{benchmark_uuid}/status/run.json"
+    manifest_key = f"runs/{run_id}/{benchmark_uuid}/manifest.json"
+    legacy_manifest_key = f"logs/{run_id}/{benchmark_uuid}/manifest.json"
+
+    status = s3_json_or_none(bucket, status_key, profile=profile)
+    manifest = s3_json_or_none(bucket, manifest_key, profile=profile)
+    if manifest is None:
+        manifest = s3_json_or_none(bucket, legacy_manifest_key, profile=profile)
+
+    timeout_hours: float | None = None
+    if manifest is not None:
+        timeout_hours = safe_float(manifest.get("timeout_hours", 24), 24.0)
+
+    status_state = ""
+    status_terminal = False
+    queue_mode = False
+    if status is not None:
+        status_state = str(status.get("state", "")).strip().lower()
+        status_terminal = bool(status.get("terminal", False)) or status_state in TERMINAL_STATES
+        mode = str(status.get("mode", "")).strip().lower()
+        queue_mode = mode == "s3_queue" or bool(status.get("queue_mode", False))
+
+    if status_terminal:
+        return Completion(
+            run_id=run_id,
+            benchmark_uuid=benchmark_uuid,
+            complete=True,
+            reason="status_terminal",
+            timeout_hours=timeout_hours,
+            queue_mode=queue_mode,
+            status_state=status_state,
+            status_terminal=True,
+        )
+
+    # Legacy fallback used when run status is absent or non-terminal.
+    try:
+        run_start = int(run_id)
+    except ValueError:
+        return Completion(
+            run_id=run_id,
+            benchmark_uuid=benchmark_uuid,
+            complete=False,
+            reason="invalid_run_id",
+            timeout_hours=timeout_hours,
+            queue_mode=queue_mode,
+            status_state=status_state,
+            status_terminal=status_terminal,
+        )
+
+    if timeout_hours is None:
+        return Completion(
+            run_id=run_id,
+            benchmark_uuid=benchmark_uuid,
+            complete=False,
+            reason="manifest_missing",
+            timeout_hours=None,
+            queue_mode=queue_mode,
+            status_state=status_state,
+            status_terminal=status_terminal,
+        )
+
+    deadline = run_start + int(timeout_hours * 3600) + int(grace_seconds)
+    complete = now >= deadline
+    return Completion(
+        run_id=run_id,
+        benchmark_uuid=benchmark_uuid,
+        complete=complete,
+        reason="legacy_deadline_met" if complete else "legacy_deadline_pending",
+        timeout_hours=timeout_hours,
+        queue_mode=queue_mode,
+        status_state=status_state,
+        status_terminal=status_terminal,
+    )
+
+
+def discover_complete_runs(
+    *,
+    bucket: str,
+    grace_seconds: int,
+    profile: str | None,
+    now: int | None = None,
+) -> list[Completion]:
+    keys = list_keys(bucket, "runs/", profile=profile)
+    candidates: list[tuple[str, str]] = []
+    for key in keys:
+        m = RUN_MANIFEST_RE.match(key)
+        if not m:
+            continue
+        candidates.append((m.group(1), m.group(2)))
+
+    seen: set[tuple[str, str]] = set()
+    result: list[Completion] = []
+    for run_id, benchmark_uuid in sorted(candidates, reverse=True):
+        pair = (run_id, benchmark_uuid)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        completion = check_run_completion(
+            bucket=bucket,
+            run_id=run_id,
+            benchmark_uuid=benchmark_uuid,
+            grace_seconds=grace_seconds,
+            profile=profile,
+            now=now,
+        )
+        if completion.complete:
+            result.append(completion)
+
+    result.sort(key=lambda r: (int(r.run_id), r.benchmark_uuid), reverse=True)
+    return result
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    completion = check_run_completion(
+        bucket=args.bucket,
+        run_id=args.run_id,
+        benchmark_uuid=args.benchmark_uuid,
+        grace_seconds=args.grace_seconds,
+        profile=args.profile,
+    )
+    if args.output == "json":
+        print(json.dumps(completion.as_dict(), separators=(",", ":")))
+    else:
+        print("complete" if completion.complete else "incomplete")
+    if args.exit_nonzero_if_incomplete and not completion.complete:
+        return 1
+    return 0
+
+
+def cmd_discover(args: argparse.Namespace) -> int:
+    completions = discover_complete_runs(
+        bucket=args.bucket,
+        grace_seconds=args.grace_seconds,
+        profile=args.profile,
+    )
+    include: list[dict[str, Any]] = []
+    for completion in completions:
+        entry: dict[str, Any] = {
+            "run_id": completion.run_id,
+            "benchmark_uuid": completion.benchmark_uuid,
+        }
+        if completion.timeout_hours is not None:
+            entry["timeout_hours"] = completion.timeout_hours
+        include.append(entry)
+    print(json.dumps({"include": include}, separators=(",", ":")))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Queue-aware run completion checks.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    check = sub.add_parser("check", help="Check if a run is complete")
+    check.add_argument("--bucket", required=True)
+    check.add_argument("--run-id", required=True)
+    check.add_argument("--benchmark-uuid", required=True)
+    check.add_argument("--grace-seconds", type=int, default=3600)
+    check.add_argument("--profile", default=None)
+    check.add_argument("--output", choices=["json", "plain"], default="json")
+    check.add_argument("--exit-nonzero-if-incomplete", action="store_true")
+    check.set_defaults(func=cmd_check)
+
+    discover = sub.add_parser("discover", help="Discover complete runs")
+    discover.add_argument("--bucket", required=True)
+    discover.add_argument("--grace-seconds", type=int, default=3600)
+    discover.add_argument("--profile", default=None)
+    discover.set_defaults(func=cmd_discover)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s3_lock.py
+++ b/scripts/s3_lock.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import random
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from typing import Any
+
+DEFAULT_LOCK_KEY = "runs/_control/global-lock.json"
+
+
+def aws_env(profile: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    if profile:
+        env["AWS_PROFILE"] = profile
+    return env
+
+
+def aws_text(args: list[str], *, profile: str | None) -> str:
+    return subprocess.check_output(["aws", *args], text=True, env=aws_env(profile))
+
+
+def s3_json_or_none(bucket: str, key: str, *, profile: str | None) -> dict[str, Any] | None:
+    try:
+        raw = aws_text(["s3", "cp", f"s3://{bucket}/{key}", "-"], profile=profile)
+    except subprocess.CalledProcessError:
+        return None
+    try:
+        value = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(value, dict):
+        return None
+    return value
+
+
+def s3_put_json(bucket: str, key: str, payload: dict[str, Any], *, profile: str | None) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tf:
+        tf.write(json.dumps(payload, separators=(",", ":")))
+        tf.write("\n")
+        temp_path = tf.name
+    try:
+        subprocess.check_call(
+            [
+                "aws",
+                "s3api",
+                "put-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--content-type",
+                "application/json",
+                "--body",
+                temp_path,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=aws_env(profile),
+        )
+    finally:
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+
+
+def s3_delete(bucket: str, key: str, *, profile: str | None) -> None:
+    subprocess.check_call(
+        ["aws", "s3api", "delete-object", "--bucket", bucket, "--key", key],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=aws_env(profile),
+    )
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(tz=dt.timezone.utc)
+
+
+def iso_utc(ts: dt.datetime) -> str:
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_epoch(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.isdigit():
+        return int(text)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except Exception:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return int(parsed.timestamp())
+
+
+def lock_expired(lock: dict[str, Any] | None, *, now_epoch: int) -> bool:
+    if not lock:
+        return True
+    expires_epoch = parse_epoch(lock.get("expires_at_epoch"))
+    if expires_epoch is None:
+        expires_epoch = parse_epoch(lock.get("expires_at"))
+    if expires_epoch is None:
+        return True
+    return now_epoch >= expires_epoch
+
+
+def build_payload(
+    *,
+    owner: str,
+    run_id: str,
+    benchmark_uuid: str,
+    lease_seconds: int,
+    previous_generation: int,
+    actor: str,
+) -> dict[str, Any]:
+    now = utc_now()
+    expires = now + dt.timedelta(seconds=max(lease_seconds, 1))
+    return {
+        "owner": owner,
+        "run_id": run_id,
+        "benchmark_uuid": benchmark_uuid,
+        "lease_seconds": int(lease_seconds),
+        "generation": int(previous_generation + 1),
+        "token": uuid.uuid4().hex,
+        "updated_by": actor,
+        "acquired_at": iso_utc(now),
+        "acquired_at_epoch": int(now.timestamp()),
+        "expires_at": iso_utc(expires),
+        "expires_at_epoch": int(expires.timestamp()),
+    }
+
+
+def cmd_read(args: argparse.Namespace) -> int:
+    now_epoch = int(time.time())
+    lock = s3_json_or_none(args.bucket, args.key, profile=args.profile)
+    if not lock:
+        print(json.dumps({"exists": False}, separators=(",", ":")))
+        return 0
+    out = {
+        "exists": True,
+        "expired": lock_expired(lock, now_epoch=now_epoch),
+        "lock": lock,
+    }
+    print(json.dumps(out, separators=(",", ":")))
+    return 0
+
+
+def cmd_acquire(args: argparse.Namespace) -> int:
+    timeout = int(args.acquire_timeout_seconds)
+    poll = max(float(args.poll_seconds), 0.25)
+    lease = max(int(args.lease_seconds), 1)
+    started = time.time()
+    actor = args.actor or f"pid-{os.getpid()}"
+
+    while True:
+        now_epoch = int(time.time())
+        lock = s3_json_or_none(args.bucket, args.key, profile=args.profile)
+        expired = lock_expired(lock, now_epoch=now_epoch)
+
+        if lock and not expired:
+            current_owner = str(lock.get("owner", ""))
+            if current_owner != args.owner:
+                if timeout > 0 and (time.time() - started) >= timeout:
+                    print(
+                        json.dumps(
+                            {
+                                "acquired": False,
+                                "reason": "timeout_waiting_for_lock",
+                                "current_owner": current_owner,
+                            },
+                            separators=(",", ":"),
+                        )
+                    )
+                    return 1
+                time.sleep(poll + random.uniform(0.0, poll * 0.25))
+                continue
+
+        previous_generation = 0
+        if lock and isinstance(lock.get("generation"), (int, float)):
+            previous_generation = int(lock["generation"])
+
+        payload = build_payload(
+            owner=args.owner,
+            run_id=args.run_id,
+            benchmark_uuid=args.benchmark_uuid,
+            lease_seconds=lease,
+            previous_generation=previous_generation,
+            actor=actor,
+        )
+        s3_put_json(args.bucket, args.key, payload, profile=args.profile)
+
+        # Re-read to verify ownership after write.
+        time.sleep(0.6)
+        confirmed = s3_json_or_none(args.bucket, args.key, profile=args.profile)
+        if confirmed and str(confirmed.get("owner", "")) == args.owner and str(confirmed.get("token", "")) == payload["token"]:
+            out = {
+                "acquired": True,
+                "lock": confirmed,
+            }
+            print(json.dumps(out, separators=(",", ":")))
+            return 0
+
+        if timeout > 0 and (time.time() - started) >= timeout:
+            print(
+                json.dumps(
+                    {
+                        "acquired": False,
+                        "reason": "timeout_race_lost",
+                    },
+                    separators=(",", ":"),
+                )
+            )
+            return 1
+
+        time.sleep(poll + random.uniform(0.0, poll * 0.25))
+
+
+def cmd_heartbeat(args: argparse.Namespace) -> int:
+    lease = max(int(args.lease_seconds), 1)
+    actor = args.actor or f"pid-{os.getpid()}"
+    now_epoch = int(time.time())
+    lock = s3_json_or_none(args.bucket, args.key, profile=args.profile)
+    if not lock:
+        print(json.dumps({"ok": False, "reason": "missing"}, separators=(",", ":")))
+        return 2
+
+    current_owner = str(lock.get("owner", ""))
+    expired = lock_expired(lock, now_epoch=now_epoch)
+    if current_owner != args.owner and not expired:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "reason": "owner_mismatch",
+                    "current_owner": current_owner,
+                },
+                separators=(",", ":"),
+            )
+        )
+        return 2
+
+    if current_owner != args.owner:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "reason": "expired_or_stolen",
+                    "current_owner": current_owner,
+                },
+                separators=(",", ":"),
+            )
+        )
+        return 2
+
+    previous_generation = 0
+    if isinstance(lock.get("generation"), (int, float)):
+        previous_generation = int(lock["generation"])
+
+    payload = build_payload(
+        owner=args.owner,
+        run_id=args.run_id,
+        benchmark_uuid=args.benchmark_uuid,
+        lease_seconds=lease,
+        previous_generation=previous_generation,
+        actor=actor,
+    )
+    s3_put_json(args.bucket, args.key, payload, profile=args.profile)
+
+    confirmed = s3_json_or_none(args.bucket, args.key, profile=args.profile)
+    if not confirmed:
+        print(json.dumps({"ok": False, "reason": "missing_after_write"}, separators=(",", ":")))
+        return 2
+
+    if str(confirmed.get("owner", "")) != args.owner:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "reason": "owner_mismatch_after_write",
+                    "current_owner": str(confirmed.get("owner", "")),
+                },
+                separators=(",", ":"),
+            )
+        )
+        return 2
+
+    print(json.dumps({"ok": True, "lock": confirmed}, separators=(",", ":")))
+    return 0
+
+
+def cmd_release(args: argparse.Namespace) -> int:
+    now_epoch = int(time.time())
+    lock = s3_json_or_none(args.bucket, args.key, profile=args.profile)
+    if not lock:
+        print(json.dumps({"released": False, "reason": "missing"}, separators=(",", ":")))
+        return 0
+
+    current_owner = str(lock.get("owner", ""))
+    expired = lock_expired(lock, now_epoch=now_epoch)
+    if current_owner != args.owner and not expired:
+        print(
+            json.dumps(
+                {
+                    "released": False,
+                    "reason": "owner_mismatch",
+                    "current_owner": current_owner,
+                },
+                separators=(",", ":"),
+            )
+        )
+        return 1
+
+    s3_delete(args.bucket, args.key, profile=args.profile)
+    print(json.dumps({"released": True}, separators=(",", ":")))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="S3-backed global run lock helper.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--bucket", required=True)
+    common.add_argument("--key", default=DEFAULT_LOCK_KEY)
+    common.add_argument("--profile", default=None)
+
+    owner_common = argparse.ArgumentParser(add_help=False)
+    owner_common.add_argument("--owner", required=True)
+    owner_common.add_argument("--run-id", required=True)
+    owner_common.add_argument("--benchmark-uuid", required=True)
+    owner_common.add_argument("--lease-seconds", type=int, default=900)
+    owner_common.add_argument("--actor", default="")
+
+    acquire = sub.add_parser("acquire", parents=[common, owner_common], help="Acquire lock")
+    acquire.add_argument("--acquire-timeout-seconds", type=int, default=0)
+    acquire.add_argument("--poll-seconds", type=float, default=5.0)
+    acquire.set_defaults(func=cmd_acquire)
+
+    heartbeat = sub.add_parser("heartbeat", parents=[common, owner_common], help="Heartbeat lock")
+    heartbeat.set_defaults(func=cmd_heartbeat)
+
+    release = sub.add_parser("release", parents=[common], help="Release lock")
+    release.add_argument("--owner", required=True)
+    release.set_defaults(func=cmd_release)
+
+    read = sub.add_parser("read", parents=[common], help="Read lock state")
+    read.set_defaults(func=cmd_read)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s3_queue_init.py
+++ b/scripts/s3_queue_init.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+
+def aws_env(profile: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    if profile:
+        env["AWS_PROFILE"] = profile
+    return env
+
+
+def aws_text(args: list[str], *, profile: str | None) -> str:
+    return subprocess.check_output(["aws", *args], text=True, env=aws_env(profile))
+
+
+def aws_json(args: list[str], *, profile: str | None) -> dict[str, Any]:
+    out = aws_text([*args, "--output", "json"], profile=profile)
+    return json.loads(out) if out.strip() else {}
+
+
+def list_keys(bucket: str, prefix: str, *, profile: str | None) -> list[str]:
+    keys: list[str] = []
+    token: str | None = None
+    while True:
+        cmd = ["s3api", "list-objects-v2", "--bucket", bucket, "--prefix", prefix]
+        if token:
+            cmd += ["--continuation-token", token]
+        data = aws_json(cmd, profile=profile)
+        keys.extend([obj["Key"] for obj in data.get("Contents", [])])
+        if not data.get("IsTruncated"):
+            break
+        token = data.get("NextContinuationToken")
+        if not token:
+            break
+    return keys
+
+
+def s3_exists(bucket: str, key: str, *, profile: str | None) -> bool:
+    try:
+        subprocess.check_call(
+            ["aws", "s3api", "head-object", "--bucket", bucket, "--key", key],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=aws_env(profile),
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def s3_json_or_none(bucket: str, key: str, *, profile: str | None) -> dict[str, Any] | None:
+    try:
+        raw = aws_text(["s3", "cp", f"s3://{bucket}/{key}", "-"], profile=profile)
+    except subprocess.CalledProcessError:
+        return None
+    try:
+        value = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(value, dict):
+        return None
+    return value
+
+
+def s3_put_json(bucket: str, key: str, payload: dict[str, Any], *, profile: str | None) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tf:
+        tf.write(json.dumps(payload, separators=(",", ":")))
+        tf.write("\n")
+        temp_path = tf.name
+    try:
+        subprocess.check_call(
+            [
+                "aws",
+                "s3api",
+                "put-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--content-type",
+                "application/json",
+                "--body",
+                temp_path,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=aws_env(profile),
+        )
+    finally:
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+
+
+def utc_now_iso() -> str:
+    return dt.datetime.now(tz=dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sanitize_fragment(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9._-]", "_", value)
+
+
+def parse_shards(encoded: str) -> list[dict[str, Any]]:
+    raw = base64.b64decode(encoded.encode("utf-8")).decode("utf-8")
+    value = json.loads(raw)
+    if not isinstance(value, list):
+        raise ValueError("decoded shard payload is not a list")
+
+    shards: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("shard entry must be an object")
+        shard_key = str(item.get("shard_key", "")).strip()
+        fuzzer_key = str(item.get("fuzzer_key", "")).strip()
+        run_index = item.get("run_index")
+        if not shard_key or not fuzzer_key:
+            raise ValueError("shard entry missing shard_key/fuzzer_key")
+        if not isinstance(run_index, int) or run_index < 0:
+            raise ValueError(f"invalid run_index for shard {shard_key}")
+        if shard_key in seen:
+            raise ValueError(f"duplicate shard_key: {shard_key}")
+        seen.add(shard_key)
+        shards.append(
+            {
+                "shard_key": shard_key,
+                "fuzzer_key": fuzzer_key,
+                "run_index": run_index,
+            }
+        )
+    return shards
+
+
+def load_shard_states(bucket: str, shard_prefix: str, *, profile: str | None) -> list[dict[str, Any]]:
+    shard_states: list[dict[str, Any]] = []
+    for key in sorted(list_keys(bucket, shard_prefix, profile=profile)):
+        if not key.endswith(".json"):
+            continue
+        shard = s3_json_or_none(bucket, key, profile=profile)
+        if shard is None:
+            continue
+        shard_states.append(shard)
+    return shard_states
+
+
+def count_states(shards: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {
+        "queued": 0,
+        "running": 0,
+        "retrying": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "timed_out": 0,
+        "total": len(shards),
+    }
+    for shard in shards:
+        status = str(shard.get("status", "")).strip().lower()
+        if status not in counts:
+            continue
+        counts[status] += 1
+    return counts
+
+
+def update_run_status(
+    *,
+    bucket: str,
+    run_status_key: str,
+    shard_prefix: str,
+    run_id: str,
+    benchmark_uuid: str,
+    lock_owner: str,
+    max_parallel_instances: int,
+    shard_max_attempts: int,
+    profile: str | None,
+) -> dict[str, Any]:
+    now = utc_now_iso()
+    existing = s3_json_or_none(bucket, run_status_key, profile=profile) or {}
+    shards = load_shard_states(bucket, shard_prefix, profile=profile)
+    counts = count_states(shards)
+
+    inflight = counts["queued"] + counts["running"] + counts["retrying"]
+    terminal = inflight == 0 and counts["total"] > 0
+    if terminal:
+        state = "failed" if (counts["failed"] + counts["timed_out"]) > 0 else "succeeded"
+    else:
+        state = "running"
+
+    payload: dict[str, Any] = {
+        "mode": "s3_queue",
+        "queue_mode": True,
+        "run_id": run_id,
+        "benchmark_uuid": benchmark_uuid,
+        "state": state,
+        "terminal": terminal,
+        "counts": counts,
+        "requested_shards": counts["total"],
+        "max_parallel_instances": max_parallel_instances,
+        "shard_max_attempts": shard_max_attempts,
+        "lock_owner": lock_owner,
+        "updated_at": now,
+    }
+
+    created_at = str(existing.get("created_at", "")).strip()
+    payload["created_at"] = created_at or now
+
+    if terminal:
+        completed_at = str(existing.get("completed_at", "")).strip()
+        payload["completed_at"] = completed_at or now
+    elif "completed_at" in existing and existing["completed_at"]:
+        payload["completed_at"] = existing["completed_at"]
+
+    s3_put_json(bucket, run_status_key, payload, profile=profile)
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Initialize S3 queue objects for a benchmark run.")
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--benchmark-uuid", required=True)
+    parser.add_argument("--shards-json-b64", required=True)
+    parser.add_argument("--max-parallel-instances", type=int, required=True)
+    parser.add_argument("--shard-max-attempts", type=int, default=3)
+    parser.add_argument("--lock-owner", required=True)
+    parser.add_argument("--profile", default=None)
+    args = parser.parse_args()
+
+    shards = parse_shards(args.shards_json_b64)
+    if not shards:
+        print("No shards were provided", file=sys.stderr)
+        return 1
+
+    root_prefix = f"runs/{args.run_id}/{args.benchmark_uuid}"
+    shard_prefix = f"{root_prefix}/queue/shards/"
+    run_status_key = f"{root_prefix}/status/run.json"
+    event_prefix = f"{root_prefix}/status/events/"
+
+    created = 0
+    now = utc_now_iso()
+    for shard in shards:
+        shard_key = shard["shard_key"]
+        shard_object_key = f"{shard_prefix}{shard_key}.json"
+        if s3_exists(args.bucket, shard_object_key, profile=args.profile):
+            continue
+
+        payload = {
+            "shard_key": shard_key,
+            "fuzzer_key": shard["fuzzer_key"],
+            "run_index": shard["run_index"],
+            "status": "queued",
+            "attempt": 0,
+            "max_attempts": int(args.shard_max_attempts),
+            "created_at": now,
+            "updated_at": now,
+            "last_worker_id": "",
+            "last_exit_code": None,
+            "retry_available_at_epoch": 0,
+            "retry_available_at": "",
+            "claim_token": "",
+        }
+        s3_put_json(args.bucket, shard_object_key, payload, profile=args.profile)
+
+        event_key = (
+            f"{event_prefix}{int(time.time() * 1000)}-bootstrap-"
+            f"{sanitize_fragment(shard_key)}-queued.json"
+        )
+        event_payload = {
+            "event_at": now,
+            "event_type": "shard_status",
+            "run_id": args.run_id,
+            "benchmark_uuid": args.benchmark_uuid,
+            "shard_key": shard_key,
+            "status": "queued",
+            "worker_id": "bootstrap",
+            "attempt": 0,
+        }
+        s3_put_json(args.bucket, event_key, event_payload, profile=args.profile)
+        created += 1
+
+    run_status = update_run_status(
+        bucket=args.bucket,
+        run_status_key=run_status_key,
+        shard_prefix=shard_prefix,
+        run_id=args.run_id,
+        benchmark_uuid=args.benchmark_uuid,
+        lock_owner=args.lock_owner,
+        max_parallel_instances=int(args.max_parallel_instances),
+        shard_max_attempts=int(args.shard_max_attempts),
+        profile=args.profile,
+    )
+
+    out = {
+        "created_shards": created,
+        "total_requested_shards": len(shards),
+        "run_status": run_status,
+    }
+    print(json.dumps(out, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s3_queue_worker.py
+++ b/scripts/s3_queue_worker.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import random
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from typing import Any
+
+LOCK_SCRIPT = "/opt/scfuzzbench/scripts/s3_lock.py"
+QUEUE_INIT_SCRIPT = "/opt/scfuzzbench/scripts/s3_queue_init.py"
+
+
+def log(message: str) -> None:
+    ts = dt.datetime.now(tz=dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{ts}] {message}", flush=True)
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Missing required env var: {name}")
+    return value
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(tz=dt.timezone.utc)
+
+
+def iso_utc(ts: dt.datetime | None = None) -> str:
+    if ts is None:
+        ts = utc_now()
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def epoch_now() -> int:
+    return int(time.time())
+
+
+def sanitize(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9._-]", "_", value)
+
+
+def aws_env() -> dict[str, str]:
+    env = os.environ.copy()
+    profile = os.environ.get("AWS_PROFILE", "").strip()
+    if profile:
+        env["AWS_PROFILE"] = profile
+    return env
+
+
+def aws_text(args: list[str]) -> str:
+    return subprocess.check_output(["aws", *args], text=True, env=aws_env())
+
+
+def aws_json(args: list[str]) -> dict[str, Any]:
+    out = aws_text([*args, "--output", "json"])
+    return json.loads(out) if out.strip() else {}
+
+
+def list_keys(bucket: str, prefix: str) -> list[str]:
+    keys: list[str] = []
+    token: str | None = None
+    while True:
+        cmd = ["s3api", "list-objects-v2", "--bucket", bucket, "--prefix", prefix]
+        if token:
+            cmd += ["--continuation-token", token]
+        data = aws_json(cmd)
+        keys.extend([obj["Key"] for obj in data.get("Contents", [])])
+        if not data.get("IsTruncated"):
+            break
+        token = data.get("NextContinuationToken")
+        if not token:
+            break
+    return keys
+
+
+def s3_json_or_none(bucket: str, key: str) -> dict[str, Any] | None:
+    try:
+        raw = aws_text(["s3", "cp", f"s3://{bucket}/{key}", "-"])
+    except subprocess.CalledProcessError:
+        return None
+    try:
+        value = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(value, dict):
+        return None
+    return value
+
+
+def s3_put_json(bucket: str, key: str, payload: dict[str, Any]) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tf:
+        tf.write(json.dumps(payload, separators=(",", ":")))
+        tf.write("\n")
+        temp_path = tf.name
+    try:
+        subprocess.check_call(
+            [
+                "aws",
+                "s3api",
+                "put-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--content-type",
+                "application/json",
+                "--body",
+                temp_path,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=aws_env(),
+        )
+    finally:
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+
+
+def call_lock_script(
+    *,
+    action: str,
+    bucket: str,
+    key: str,
+    owner: str,
+    run_id: str,
+    benchmark_uuid: str,
+    lease_seconds: int,
+    actor: str,
+    acquire_timeout_seconds: int = 0,
+    poll_seconds: float = 5.0,
+) -> tuple[int, str]:
+    cmd = [
+        "python3",
+        LOCK_SCRIPT,
+        action,
+        "--bucket",
+        bucket,
+        "--key",
+        key,
+        "--owner",
+        owner,
+        "--lease-seconds",
+        str(lease_seconds),
+        "--actor",
+        actor,
+    ]
+    if action in {"acquire", "heartbeat"}:
+        cmd += ["--run-id", run_id, "--benchmark-uuid", benchmark_uuid]
+    if action == "acquire":
+        cmd += [
+            "--acquire-timeout-seconds",
+            str(acquire_timeout_seconds),
+            "--poll-seconds",
+            str(poll_seconds),
+        ]
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    output = (proc.stdout or "").strip() or (proc.stderr or "").strip()
+    return proc.returncode, output
+
+
+def parse_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def shard_counts(shards: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {
+        "queued": 0,
+        "running": 0,
+        "retrying": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "timed_out": 0,
+        "total": len(shards),
+    }
+    for shard in shards:
+        status = str(shard.get("status", "")).strip().lower()
+        if status in counts:
+            counts[status] += 1
+    return counts
+
+
+def maybe_instance_id() -> str:
+    # Try IMDSv2 first for stable worker identity, then fallback to hostname.
+    try:
+        token_req = urllib.request.Request(
+            "http://169.254.169.254/latest/api/token",
+            method="PUT",
+            headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+        )
+        with urllib.request.urlopen(token_req, timeout=1.0) as resp:
+            token = resp.read().decode("utf-8").strip()
+        if token:
+            id_req = urllib.request.Request(
+                "http://169.254.169.254/latest/meta-data/instance-id",
+                headers={"X-aws-ec2-metadata-token": token},
+            )
+            with urllib.request.urlopen(id_req, timeout=1.0) as resp:
+                instance_id = resp.read().decode("utf-8").strip()
+            if instance_id:
+                return instance_id
+    except Exception:
+        pass
+
+    env_instance = os.environ.get("SCFUZZBENCH_INSTANCE_ID", "").strip()
+    if env_instance:
+        return env_instance
+
+    return socket.gethostname().strip() or f"worker-{uuid.uuid4().hex[:8]}"
+
+
+class QueueWorker:
+    def __init__(self) -> None:
+        self.bucket = require_env("SCFUZZBENCH_S3_BUCKET")
+        self.run_id = require_env("SCFUZZBENCH_RUN_ID")
+        self.benchmark_uuid = require_env("SCFUZZBENCH_BENCHMARK_UUID")
+        self.lock_owner = require_env("SCFUZZBENCH_LOCK_OWNER")
+        self.lock_key = os.environ.get("SCFUZZBENCH_LOCK_KEY", "").strip() or "runs/_control/global-lock.json"
+
+        self.max_parallel_instances = env_int("SCFUZZBENCH_MAX_PARALLEL_INSTANCES", 1)
+        self.shard_max_attempts = max(env_int("SCFUZZBENCH_SHARD_MAX_ATTEMPTS", 3), 1)
+        self.lock_lease_seconds = max(env_int("SCFUZZBENCH_LOCK_LEASE_SECONDS", 900), 30)
+        self.lock_heartbeat_seconds = max(env_int("SCFUZZBENCH_LOCK_HEARTBEAT_SECONDS", 60), 15)
+        self.lock_acquire_timeout_seconds = max(env_int("SCFUZZBENCH_LOCK_ACQUIRE_TIMEOUT_SECONDS", 0), 0)
+        self.poll_seconds = max(env_int("SCFUZZBENCH_QUEUE_POLL_SECONDS", 15), 5)
+        self.idle_polls_before_exit = max(env_int("SCFUZZBENCH_QUEUE_IDLE_POLLS_BEFORE_EXIT", 6), 1)
+
+        self.shards_json_b64 = require_env("SCFUZZBENCH_SHARDS_JSON_B64")
+
+        self.worker_id = maybe_instance_id()
+        self.hostname = socket.gethostname().strip()
+
+        self.root_prefix = f"runs/{self.run_id}/{self.benchmark_uuid}"
+        self.shard_prefix = f"{self.root_prefix}/queue/shards/"
+        self.run_status_key = f"{self.root_prefix}/status/run.json"
+        self.worker_status_key = f"{self.root_prefix}/status/workers/{sanitize(self.worker_id)}.json"
+        self.event_prefix = f"{self.root_prefix}/status/events/"
+        self.dlq_prefix = f"{self.root_prefix}/dlq/"
+
+        self.stop_event = threading.Event()
+        self.lock_lost_event = threading.Event()
+        self.heartbeat_thread: threading.Thread | None = None
+        self.last_run_state = ""
+
+    def emit_event(self, *, shard_key: str, status: str, event_type: str, details: dict[str, Any] | None = None) -> None:
+        payload: dict[str, Any] = {
+            "event_at": iso_utc(),
+            "event_type": event_type,
+            "run_id": self.run_id,
+            "benchmark_uuid": self.benchmark_uuid,
+            "worker_id": self.worker_id,
+            "shard_key": shard_key,
+            "status": status,
+        }
+        if details:
+            payload.update(details)
+        key = (
+            f"{self.event_prefix}{int(time.time() * 1000)}-"
+            f"{sanitize(self.worker_id)}-{sanitize(shard_key)}-{sanitize(status)}-"
+            f"{uuid.uuid4().hex[:8]}.json"
+        )
+        s3_put_json(self.bucket, key, payload)
+
+    def update_worker_status(self, *, state: str, shard_key: str = "", attempt: int = 0, exit_code: int | None = None) -> None:
+        payload: dict[str, Any] = {
+            "run_id": self.run_id,
+            "benchmark_uuid": self.benchmark_uuid,
+            "worker_id": self.worker_id,
+            "hostname": self.hostname,
+            "lock_owner": self.lock_owner,
+            "state": state,
+            "current_shard": shard_key,
+            "attempt": attempt,
+            "updated_at": iso_utc(),
+        }
+        if exit_code is not None:
+            payload["last_exit_code"] = int(exit_code)
+        s3_put_json(self.bucket, self.worker_status_key, payload)
+
+    def load_shards(self) -> list[tuple[str, dict[str, Any]]]:
+        out: list[tuple[str, dict[str, Any]]] = []
+        for key in sorted(list_keys(self.bucket, self.shard_prefix)):
+            if not key.endswith(".json"):
+                continue
+            shard = s3_json_or_none(self.bucket, key)
+            if shard is None:
+                continue
+            out.append((key, shard))
+        return out
+
+    def refresh_run_status(self) -> dict[str, Any]:
+        existing = s3_json_or_none(self.bucket, self.run_status_key) or {}
+        shards = [item[1] for item in self.load_shards()]
+        counts = shard_counts(shards)
+        inflight = counts["queued"] + counts["running"] + counts["retrying"]
+        terminal = inflight == 0 and counts["total"] > 0
+
+        if terminal:
+            state = "failed" if (counts["failed"] + counts["timed_out"]) > 0 else "succeeded"
+        else:
+            state = "running"
+
+        payload: dict[str, Any] = {
+            "mode": "s3_queue",
+            "queue_mode": True,
+            "run_id": self.run_id,
+            "benchmark_uuid": self.benchmark_uuid,
+            "state": state,
+            "terminal": terminal,
+            "counts": counts,
+            "requested_shards": counts["total"],
+            "max_parallel_instances": self.max_parallel_instances,
+            "shard_max_attempts": self.shard_max_attempts,
+            "lock_owner": self.lock_owner,
+            "updated_at": iso_utc(),
+        }
+
+        created_at = str(existing.get("created_at", "")).strip()
+        payload["created_at"] = created_at or payload["updated_at"]
+
+        if terminal:
+            completed_at = str(existing.get("completed_at", "")).strip()
+            payload["completed_at"] = completed_at or payload["updated_at"]
+        elif "completed_at" in existing and existing["completed_at"]:
+            payload["completed_at"] = existing["completed_at"]
+
+        s3_put_json(self.bucket, self.run_status_key, payload)
+
+        if state != self.last_run_state:
+            self.emit_event(
+                shard_key="run",
+                status=state,
+                event_type="run_status",
+                details={
+                    "counts": counts,
+                    "terminal": terminal,
+                },
+            )
+            self.last_run_state = state
+
+        return payload
+
+    def heartbeat_loop(self) -> None:
+        while not self.stop_event.wait(self.lock_heartbeat_seconds):
+            rc, out = call_lock_script(
+                action="heartbeat",
+                bucket=self.bucket,
+                key=self.lock_key,
+                owner=self.lock_owner,
+                run_id=self.run_id,
+                benchmark_uuid=self.benchmark_uuid,
+                lease_seconds=self.lock_lease_seconds,
+                actor=self.worker_id,
+            )
+            if rc != 0:
+                self.lock_lost_event.set()
+                log(f"Lock heartbeat failed: {out}")
+                return
+
+    def acquire_lock(self) -> None:
+        rc, out = call_lock_script(
+            action="acquire",
+            bucket=self.bucket,
+            key=self.lock_key,
+            owner=self.lock_owner,
+            run_id=self.run_id,
+            benchmark_uuid=self.benchmark_uuid,
+            lease_seconds=self.lock_lease_seconds,
+            acquire_timeout_seconds=self.lock_acquire_timeout_seconds,
+            poll_seconds=5.0,
+            actor=self.worker_id,
+        )
+        if rc != 0:
+            raise RuntimeError(f"failed to acquire lock: {out}")
+        log("Global S3 lock acquired")
+
+    def release_lock(self) -> None:
+        cmd = [
+            "python3",
+            LOCK_SCRIPT,
+            "release",
+            "--bucket",
+            self.bucket,
+            "--key",
+            self.lock_key,
+            "--owner",
+            self.lock_owner,
+        ]
+        proc = subprocess.run(cmd, text=True, capture_output=True)
+        if proc.returncode == 0:
+            log("Released global S3 lock")
+        else:
+            stderr = (proc.stderr or "").strip()
+            stdout = (proc.stdout or "").strip()
+            details = stdout or stderr or "unknown"
+            log(f"Lock release skipped/failed: {details}")
+
+    def initialize_queue(self) -> None:
+        cmd = [
+            "python3",
+            QUEUE_INIT_SCRIPT,
+            "--bucket",
+            self.bucket,
+            "--run-id",
+            self.run_id,
+            "--benchmark-uuid",
+            self.benchmark_uuid,
+            "--shards-json-b64",
+            self.shards_json_b64,
+            "--max-parallel-instances",
+            str(self.max_parallel_instances),
+            "--shard-max-attempts",
+            str(self.shard_max_attempts),
+            "--lock-owner",
+            self.lock_owner,
+        ]
+        subprocess.check_call(cmd)
+
+    def claim_shard(self) -> tuple[str, dict[str, Any]] | None:
+        now_epoch = epoch_now()
+        for key, shard in self.load_shards():
+            status = str(shard.get("status", "")).strip().lower()
+            if status not in {"queued", "retrying"}:
+                continue
+
+            retry_epoch = parse_int(shard.get("retry_available_at_epoch"), 0)
+            if status == "retrying" and now_epoch < retry_epoch:
+                continue
+
+            attempt = parse_int(shard.get("attempt"), 0)
+            max_attempts = max(parse_int(shard.get("max_attempts"), self.shard_max_attempts), 1)
+            if attempt >= max_attempts:
+                shard["status"] = "failed"
+                shard["updated_at"] = iso_utc()
+                shard["last_worker_id"] = self.worker_id
+                shard["last_exit_code"] = parse_int(shard.get("last_exit_code"), 1)
+                s3_put_json(self.bucket, key, shard)
+                self.emit_event(
+                    shard_key=str(shard.get("shard_key", key)),
+                    status="failed",
+                    event_type="shard_status",
+                    details={"reason": "attempts_exhausted"},
+                )
+                continue
+
+            claim_token = uuid.uuid4().hex
+            shard["status"] = "running"
+            shard["attempt"] = attempt + 1
+            shard["claim_token"] = claim_token
+            shard["updated_at"] = iso_utc()
+            shard["started_at"] = shard["updated_at"]
+            shard["last_worker_id"] = self.worker_id
+            shard["retry_available_at_epoch"] = 0
+            shard["retry_available_at"] = ""
+            s3_put_json(self.bucket, key, shard)
+
+            time.sleep(0.6)
+            confirmed = s3_json_or_none(self.bucket, key)
+            if not confirmed:
+                continue
+            if str(confirmed.get("claim_token", "")) != claim_token:
+                continue
+            if str(confirmed.get("status", "")).strip().lower() != "running":
+                continue
+
+            shard_key = str(confirmed.get("shard_key", "")).strip() or key.rsplit("/", 1)[-1].removesuffix(".json")
+            self.emit_event(
+                shard_key=shard_key,
+                status="running",
+                event_type="shard_status",
+                details={
+                    "attempt": parse_int(confirmed.get("attempt"), 1),
+                },
+            )
+            return key, confirmed
+        return None
+
+    def run_shard(self, shard: dict[str, Any]) -> int:
+        shard_key = str(shard.get("shard_key", "")).strip()
+        fuzzer_key = str(shard.get("fuzzer_key", "")).strip()
+        attempt = parse_int(shard.get("attempt"), 1)
+        if not shard_key or not fuzzer_key:
+            return 2
+
+        script_path = f"/opt/scfuzzbench/fuzzers/{fuzzer_key}/run.sh"
+        if not os.path.isfile(script_path):
+            log(f"Missing run script for fuzzer '{fuzzer_key}'")
+            return 127
+
+        safe_shard = sanitize(shard_key)
+        workdir = f"/opt/scfuzzbench/work/{safe_shard}/attempt-{attempt}"
+        logdir = f"/opt/scfuzzbench/logs/{safe_shard}/attempt-{attempt}"
+
+        shutil.rmtree(workdir, ignore_errors=True)
+        shutil.rmtree(logdir, ignore_errors=True)
+        os.makedirs(workdir, exist_ok=True)
+        os.makedirs(logdir, exist_ok=True)
+
+        env = os.environ.copy()
+        env["SCFUZZBENCH_QUEUE_MODE"] = "1"
+        env["SCFUZZBENCH_WORKDIR"] = workdir
+        env["SCFUZZBENCH_LOG_DIR"] = logdir
+        env["SCFUZZBENCH_SHARD_KEY"] = shard_key
+        env["SCFUZZBENCH_SHARD_ATTEMPT"] = str(attempt)
+
+        log(f"Running shard '{shard_key}' (fuzzer={fuzzer_key}, attempt={attempt})")
+        proc = subprocess.run(["bash", script_path], env=env)
+        return int(proc.returncode)
+
+    def dlq(self, shard: dict[str, Any], exit_code: int, status: str) -> None:
+        shard_key = str(shard.get("shard_key", "")).strip()
+        attempt = parse_int(shard.get("attempt"), 1)
+        key = f"{self.dlq_prefix}{sanitize(shard_key)}-{attempt}.json"
+        payload = {
+            "run_id": self.run_id,
+            "benchmark_uuid": self.benchmark_uuid,
+            "shard_key": shard_key,
+            "status": status,
+            "attempt": attempt,
+            "max_attempts": parse_int(shard.get("max_attempts"), self.shard_max_attempts),
+            "exit_code": int(exit_code),
+            "worker_id": self.worker_id,
+            "failed_at": iso_utc(),
+        }
+        s3_put_json(self.bucket, key, payload)
+
+    def complete_shard(self, key: str, shard: dict[str, Any], exit_code: int) -> None:
+        shard_key = str(shard.get("shard_key", "")).strip()
+        attempt = parse_int(shard.get("attempt"), 1)
+        max_attempts = max(parse_int(shard.get("max_attempts"), self.shard_max_attempts), 1)
+
+        if exit_code == 0:
+            terminal_status = "succeeded"
+        elif exit_code == 124:
+            terminal_status = "timed_out"
+        else:
+            terminal_status = "failed"
+
+        now = utc_now()
+        now_iso = iso_utc(now)
+
+        shard["updated_at"] = now_iso
+        shard["finished_at"] = now_iso
+        shard["last_worker_id"] = self.worker_id
+        shard["last_exit_code"] = int(exit_code)
+        shard["claim_token"] = ""
+
+        if terminal_status == "succeeded":
+            shard["status"] = "succeeded"
+            shard["retry_available_at_epoch"] = 0
+            shard["retry_available_at"] = ""
+            s3_put_json(self.bucket, key, shard)
+            self.emit_event(
+                shard_key=shard_key,
+                status="succeeded",
+                event_type="shard_status",
+                details={"attempt": attempt, "exit_code": exit_code},
+            )
+            return
+
+        if attempt < max_attempts:
+            retry_seconds = min(300, (2 ** max(attempt - 1, 0)) * 30)
+            retry_at = now + dt.timedelta(seconds=retry_seconds)
+            shard["status"] = "retrying"
+            shard["retry_available_at_epoch"] = int(retry_at.timestamp())
+            shard["retry_available_at"] = iso_utc(retry_at)
+            s3_put_json(self.bucket, key, shard)
+            self.emit_event(
+                shard_key=shard_key,
+                status="retrying",
+                event_type="shard_status",
+                details={
+                    "attempt": attempt,
+                    "exit_code": exit_code,
+                    "retry_in_seconds": retry_seconds,
+                    "next_retry_at": shard["retry_available_at"],
+                },
+            )
+            return
+
+        shard["status"] = terminal_status
+        shard["retry_available_at_epoch"] = 0
+        shard["retry_available_at"] = ""
+        s3_put_json(self.bucket, key, shard)
+        self.emit_event(
+            shard_key=shard_key,
+            status=terminal_status,
+            event_type="shard_status",
+            details={"attempt": attempt, "exit_code": exit_code},
+        )
+        self.dlq(shard, exit_code=exit_code, status=terminal_status)
+
+    def start_heartbeat(self) -> None:
+        self.heartbeat_thread = threading.Thread(target=self.heartbeat_loop, name="lock-heartbeat", daemon=True)
+        self.heartbeat_thread.start()
+
+    def stop_heartbeat(self) -> None:
+        self.stop_event.set()
+        if self.heartbeat_thread and self.heartbeat_thread.is_alive():
+            self.heartbeat_thread.join(timeout=5.0)
+
+    def run(self) -> int:
+        self.acquire_lock()
+        self.start_heartbeat()
+
+        try:
+            self.initialize_queue()
+            self.refresh_run_status()
+            self.update_worker_status(state="idle")
+
+            idle_polls = 0
+            while True:
+                if self.lock_lost_event.is_set():
+                    raise RuntimeError("lock heartbeat failed; stopping worker")
+
+                claimed = self.claim_shard()
+                if claimed is None:
+                    run_status = self.refresh_run_status()
+                    if bool(run_status.get("terminal", False)):
+                        log(f"Run reached terminal state: {run_status.get('state', '')}")
+                        break
+
+                    idle_polls += 1
+                    self.update_worker_status(state="idle")
+                    sleep_seconds = self.poll_seconds + random.randint(0, 3)
+                    if idle_polls >= self.idle_polls_before_exit:
+                        idle_polls = 0
+                    time.sleep(sleep_seconds)
+                    continue
+
+                idle_polls = 0
+                key, shard = claimed
+                shard_key = str(shard.get("shard_key", "")).strip()
+                attempt = parse_int(shard.get("attempt"), 1)
+                self.update_worker_status(state="running", shard_key=shard_key, attempt=attempt)
+
+                exit_code = self.run_shard(shard)
+                self.update_worker_status(state="idle", shard_key=shard_key, attempt=attempt, exit_code=exit_code)
+                self.complete_shard(key, shard, exit_code)
+                run_status = self.refresh_run_status()
+                if bool(run_status.get("terminal", False)):
+                    log(f"Run reached terminal state: {run_status.get('state', '')}")
+                    break
+
+            final_status = s3_json_or_none(self.bucket, self.run_status_key) or {}
+            self.update_worker_status(state="stopped")
+            if bool(final_status.get("terminal", False)):
+                self.release_lock()
+            return 0
+
+        finally:
+            self.stop_heartbeat()
+
+
+def main() -> int:
+    try:
+        worker = QueueWorker()
+        return worker.run()
+    except Exception as exc:
+        log(f"Queue worker fatal error: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #37

## Summary
- Implement S3-only queue orchestration with shard state, run/worker/event status, event history, DLQ, and a global S3 lease lock.
- Refactor Terraform from per-shard EC2 fan-out to a fixed worker pool (`max_parallel_instances`).
- Bootstrap workers from the repository archive at `scfuzzbench_commit`, then install selected fuzzers and run the queue worker loop.
- Make release/docs completion status-aware via `runs/<run_id>/<benchmark_uuid>/status/run.json`, with legacy timeout fallback.
- Update benchmark request/run workflows and docs for explicit parallelism and queue-mode completion semantics.

## Validation
- `make terraform-fmt`
- `make terraform-validate`
- `python3 -m compileall scripts analysis`
- `bash -n fuzzers/_shared/common.sh`
- `bash -n infrastructure/user_data.sh.tftpl`
- `actionlint .github/workflows/*.yml`
