### PR TITLE
Make median time-to-k chart single hue with k-based shades

### DIFF
--- a/analysis/benchmark_report.py
+++ b/analysis/benchmark_report.py
@@ -292,13 +292,28 @@ def plot_time_to_k(
     fuzzers = [label_map.get(m.fuzzer, m.fuzzer) if label_map else m.fuzzer for m in metrics]
     x = np.arange(len(fuzzers))
     width = 0.8 / max(1, len(ks))
+    cmap = plt.get_cmap("Purples")
+    sorted_ks = sorted(ks)
+    k_rank = {k: idx for idx, k in enumerate(sorted_ks)}
+    min_shade = 0.45
+    max_shade = 0.9
 
     for j, k in enumerate(ks):
         vals = []
         for metric in metrics:
             t = metric.time_to_k_p50[k]
             vals.append(np.nan if not math.isfinite(t) else t)
-        plt.bar(x + (j - (len(ks) - 1) / 2) * width, vals, width=width, label=f"k={k}")
+        if len(ks) == 1:
+            shade = max_shade
+        else:
+            shade = min_shade + (max_shade - min_shade) * (k_rank[k] / (len(ks) - 1))
+        plt.bar(
+            x + (j - (len(ks) - 1) / 2) * width,
+            vals,
+            width=width,
+            label=f"k={k}",
+            color=cmap(shade),
+        )
 
     plt.xticks(x, fuzzers)
     plt.ylabel("Median time-to-k (hours)")


### PR DESCRIPTION
## Summary
- update `plot_time_to_k` to use a single purple palette (`Purples`)
- map lower `k` to lighter shades and higher `k` to darker shades
- keep existing grouped bars/legend semantics unchanged

Closes #50
