### PR TITLE
docs(target-onboarding): add Echidna 0-issues prefix watch-out

### DIFF
--- a/skills/target-onboarding/SKILL.md
+++ b/skills/target-onboarding/SKILL.md
@@ -91,7 +91,7 @@ Echidna:
 3. use assertion-mode config that matches recon harness invariants:
    - `testMode: "assertion"`
    - `prefix: "invariant_"`
-   - do not use `prefix: "property_"` for this setup
+   - make sure Echidna and Medusa global invariants are prefixed with `invariant_` instead of `property_` or `echidna_`
 
 Medusa:
 1. use concrete compilation target file (not `"."`)


### PR DESCRIPTION
## Summary
- add a `Common failures and fixes` watch-out for Echidna runs that report 0 issues unexpectedly
- document the `testMode: "assertion"` + `prefix: "property_"` pitfall seen on some recon harnesses
- recommend retrying with `prefix: "invariant_"` and rerunning smoke + 10-minute trial

## Validation
- reran Liquity V2 smoke with patched prefix (`invariant_`) using:
  - `timeout -k 5s 600s echidna test/recon/CryticTester.sol --contract CryticTester --config echidna.yaml --format text`
- outcome: bug reproduced (`property_GV01()` falsified / failed)
- run exited non-zero (`EXIT:1`) after reaching test limit, confirming this is not a 0-issues case under the patched prefix
