### PR TITLE
docs(skill): enforce invariant_ naming and echidna/medusa prefix policy

### DIFF
--- a/skills/target-onboarding/SKILL.md
+++ b/skills/target-onboarding/SKILL.md
@@ -140,7 +140,7 @@ Echidna:
    - global invariants in harness code must use `invariant_` (never `property_` or `crytic_`)
    - `echidna.yaml` should use `testMode: "assertion"`
    - `echidna.yaml` should use `prefix: "echidna_"`
-   - rationale: in assertion mode, Echidna should catch assertion failures plus `echidna_` global properties in one run
+   - rationale: in assertion mode, Echidna should catch assertion failures plus global properties in one run, so cannot use prefix "invariant"
 
 Medusa:
 1. use concrete compilation target file (not `"."`)


### PR DESCRIPTION
## Summary
- update `skills/target-onboarding/SKILL.md` to enforce global invariant naming as `invariant_` (and explicitly disallow `property_` / `crytic_` for global invariants)
- update Echidna guidance:
  - use `testMode: "assertion"`
  - use `prefix: "echidna_"` in `echidna.yaml`
  - rationale documented: assertion mode should catch assertion failures plus `echidna_` global properties
- update Medusa guidance:
  - keep property prefix as `invariant_` in `medusa.json`
  - rationale documented: Medusa can run property + assertion simultaneously
- update troubleshooting and command examples to match the above

## Why
Align the onboarding SKILL with current desired fuzzer behavior and prefix conventions.
