### PR TITLE
Fix runner metrics discovery when prepared filenames are prefixed

### DIFF
--- a/analysis/runner_metrics_report.py
+++ b/analysis/runner_metrics_report.py
@@ -47,6 +47,13 @@ TIMESERIES_COLS = [
 ]
 
 
+def is_runner_metrics_csv(path: Path) -> bool:
+    name = path.name.lower()
+    if not name.endswith(".csv"):
+        return False
+    return "runner_metrics" in name or "runner-metrics" in name
+
+
 def infer_elapsed_seconds(df: pd.DataFrame) -> pd.Series:
     ts = pd.to_datetime(df.get("timestamp"), utc=True, errors="coerce")
     if ts.notna().any():
@@ -143,9 +150,7 @@ def load_metrics_for_instance(
 def collect_metrics(logs_dir: Path, run_id: str, budget_hours: Optional[float]) -> pd.DataFrame:
     frames: List[pd.DataFrame] = []
     for instance_dir in sorted(path for path in logs_dir.iterdir() if path.is_dir()):
-        metrics_files = sorted(
-            path for path in instance_dir.rglob("*.csv") if path.name.startswith("runner_metrics")
-        )
+        metrics_files = sorted(path for path in instance_dir.rglob("*.csv") if is_runner_metrics_csv(path))
         for metrics_path in metrics_files:
             frame = load_metrics_for_instance(
                 metrics_path=metrics_path,

--- a/analysis/tests/test_prepare_analysis_logs.py
+++ b/analysis/tests/test_prepare_analysis_logs.py
@@ -1,0 +1,43 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "prepare_analysis_logs.py"
+
+
+class PrepareAnalysisLogsTests(unittest.TestCase):
+    def test_keeps_runner_metrics_basename_when_unique(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            unzipped_dir = tmp_dir / "unzipped" / "i-aaa-foundry"
+            (unzipped_dir / "logs").mkdir(parents=True, exist_ok=True)
+            (unzipped_dir / "logs" / "fuzzer.log").write_text("hello\n", encoding="utf-8")
+            (unzipped_dir / "logs" / "runner_metrics.csv").write_text(
+                "timestamp,uptime_seconds,cpu_user_pct,cpu_system_pct,cpu_iowait_pct,mem_total_kb,mem_used_kb\n"
+                "2026-02-23T00:00:00+00:00,1,1,1,1,1000,500\n",
+                encoding="utf-8",
+            )
+
+            out_dir = tmp_dir / "prepared"
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--unzipped-dir",
+                    str(tmp_dir / "unzipped"),
+                    "--out-dir",
+                    str(out_dir),
+                ]
+            )
+
+            prepared_instance = out_dir / "i-aaa-foundry"
+            self.assertTrue((prepared_instance / "fuzzer.log").exists())
+            self.assertTrue((prepared_instance / "runner_metrics.csv").exists())
+            self.assertFalse((prepared_instance / "logs__runner_metrics.csv").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/analysis/tests/test_runner_metrics_report.py
+++ b/analysis/tests/test_runner_metrics_report.py
@@ -135,6 +135,55 @@ class RunnerMetricsReportTests(unittest.TestCase):
             self.assertTrue(cpu_png.exists())
             self.assertTrue(memory_png.exists())
 
+    def test_accepts_prefixed_runner_metrics_filename(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            logs_dir = tmp_dir / "logs"
+            self.write_metrics_csv(
+                logs_dir / "i-aaa-foundry" / "logs__runner_metrics.csv",
+                [
+                    "2026-02-23T00:00:00+00:00,1000,0.1,0.1,0.1,10,5,80,5,1000000,700000,300000,0,0,0",
+                    "2026-02-23T00:00:20+00:00,1020,0.2,0.2,0.2,20,10,65,5,1000000,600000,400000,0,0,0",
+                ],
+            )
+
+            out_summary = tmp_dir / "runner_resource_summary.csv"
+            out_timeseries = tmp_dir / "runner_resource_timeseries.csv"
+            out_md = tmp_dir / "runner_resource_usage.md"
+            cpu_png = tmp_dir / "cpu_usage_over_time.png"
+            memory_png = tmp_dir / "memory_usage_over_time.png"
+
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--logs-dir",
+                    str(logs_dir),
+                    "--out-summary-csv",
+                    str(out_summary),
+                    "--out-timeseries-csv",
+                    str(out_timeseries),
+                    "--out-md",
+                    str(out_md),
+                    "--out-cpu-png",
+                    str(cpu_png),
+                    "--out-memory-png",
+                    str(memory_png),
+                    "--run-id",
+                    "1772000001",
+                ]
+            )
+
+            with out_summary.open("r", newline="", encoding="utf-8") as handle:
+                summary_rows = list(csv.DictReader(handle))
+            with out_timeseries.open("r", newline="", encoding="utf-8") as handle:
+                timeseries_rows = list(csv.DictReader(handle))
+
+            self.assertEqual(1, len(summary_rows))
+            self.assertEqual("foundry", summary_rows[0]["fuzzer"])
+            self.assertTrue(timeseries_rows)
+            self.assertNotIn("No `runner_metrics*.csv` files were found", out_md.read_text(encoding="utf-8"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/prepare_analysis_logs.py
+++ b/scripts/prepare_analysis_logs.py
@@ -5,6 +5,13 @@ import shutil
 import sys
 
 
+def is_runner_metrics_csv(path: Path) -> bool:
+    name = path.name.lower()
+    if not name.endswith(".csv"):
+        return False
+    return "runner_metrics" in name or "runner-metrics" in name
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Collect .log files and runner metrics CSVs for analysis."
@@ -22,9 +29,7 @@ def main() -> int:
     copied_metrics = 0
     for instance_dir in sorted(p for p in args.unzipped_dir.iterdir() if p.is_dir()):
         log_files = list(instance_dir.rglob("*.log"))
-        metric_files = [
-            path for path in instance_dir.rglob("*.csv") if path.name.startswith("runner_metrics")
-        ]
+        metric_files = [path for path in instance_dir.rglob("*.csv") if is_runner_metrics_csv(path)]
         if not log_files and not metric_files:
             continue
         dest_instance = args.out_dir / instance_dir.name
@@ -32,12 +37,27 @@ def main() -> int:
         for log_file in log_files:
             shutil.copy2(log_file, dest_instance / log_file.name)
             copied_logs += 1
+        used_metric_names: set[str] = set()
         for metric_file in metric_files:
-            rel = metric_file.relative_to(instance_dir)
-            # Preserve uniqueness if multiple metrics files exist under different subpaths.
-            suffix = "__".join(rel.parts[:-1])
-            out_name = metric_file.name if not suffix else f"{suffix}__{metric_file.name}"
+            # Keep the canonical name when unique; add a path prefix only on collision.
+            out_name = metric_file.name
+            if out_name in used_metric_names:
+                rel = metric_file.relative_to(instance_dir)
+                prefix = "__".join(rel.parts[:-1])
+                if prefix:
+                    out_name = f"{prefix}__{metric_file.name}"
+            if out_name in used_metric_names:
+                stem = Path(metric_file.name).stem
+                suffix = Path(metric_file.name).suffix
+                idx = 2
+                while True:
+                    candidate = f"{stem}__{idx}{suffix}"
+                    if candidate not in used_metric_names:
+                        out_name = candidate
+                        break
+                    idx += 1
             shutil.copy2(metric_file, dest_instance / out_name)
+            used_metric_names.add(out_name)
             copied_metrics += 1
     print(
         f"Copied {copied_logs} log file(s) and {copied_metrics} runner metrics file(s) to {args.out_dir}"


### PR DESCRIPTION
## Summary
- fix runner metrics discovery to match files containing `runner_metrics` (not only names starting with it)
- update `prepare_analysis_logs.py` to keep `runner_metrics.csv` basename when unique, avoiding unnecessary `logs__` prefixes
- preserve collision handling for edge cases with multiple metrics files per instance
- add regression tests for:
  - prefixed metrics filenames in `runner_metrics_report.py`
  - prepare step preserving `runner_metrics.csv` basename for normal layout

## Validation
- `.venv-analysis/bin/python -m unittest discover -s analysis/tests -p 'test_*.py'`
- local repro on real run artifacts confirmed non-empty runner resource output after the fix
