### PR TITLE
docs(target-onboarding): require exact ASSERTION_* suffix normalization

### DIFF
--- a/skills/target-onboarding/SKILL.md
+++ b/skills/target-onboarding/SKILL.md
@@ -53,8 +53,10 @@ Optional:
    - `ASSERTION_CONSTANT_SUFFIX` must exactly match the referenced `ASSERTION_*` constant suffix
      - example: `ASSERTION_WITHDRAW_DOS` -> `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS(...)`
    - Foundry wrappers must use `invariant_assertion_failure_targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>()`
+     - example: `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS` -> `invariant_assertion_failure_iSpoke_withdraw_ASSERTION_WITHDRAW_DOS()`
    - wrapper suffix after `invariant_assertion_failure_` must exactly match the handler identifier (`targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`)
    - canonical cross-fuzzer identifier for assertions is always `targetFunctionName` (strip `_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>` and strip Foundry wrapper prefix)
+     - example: `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS` -> `iSpoke_withdraw`
 
 ## Workflow
 
@@ -243,7 +245,7 @@ timeout 300 medusa fuzz --config medusa.json --timeout 300
 timeout 300 forge test --match-contract CryticToFoundry --match-test 'invariant_' -vv
 ```
 
-Do not mark onboarding complete based only on a 10-minute run. Completion is tied to the 5-minute 2-canary acceptance gate above.
+Completion is tied to the 5-minute 2-canary acceptance gate above.
 
 Debug-only fallback for Foundry output inspection:
 


### PR DESCRIPTION
## Summary
- clarify that `<ASSERTION_CONSTANT_SUFFIX>` must exactly match the referenced `ASSERTION_*` constant suffix
- add concrete examples (`..._ASSERTION_WITHDRAW_DOS`, `..._ASSERTION_MINT_FEE_SHARES_PPS_CHANGE`)
- update normalization guidance in constraints, workflow checks, common failures, and completion checklist

## Why
Recent onboarding work surfaced ambiguity around short IDs like `_ASSERTION_DOS` and `_ASSERTION_PPS_CHANGE`.
This makes the rule explicit so handler/wrapper names are deterministic and parser-normalization-safe across fuzzers.
