### PR TITLE
Normalize broken assertion IDs in invariant overlap

### DIFF
--- a/analysis/invariant_overlap_report.py
+++ b/analysis/invariant_overlap_report.py
@@ -24,6 +24,8 @@ QUALIFIED_EVENT_RE = re.compile(
     r"^(?:[A-Za-z_][A-Za-z0-9_$]*\.)+(?P<name>[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?)$"
 )
 TRAILING_PARAMS_RE = re.compile(r"\([^()]*\)$")
+ASSERTION_SUFFIX_RE = re.compile(r"_ASSERTION_[A-Za-z0-9_]+$")
+FOUNDRY_ASSERTION_WRAPPER_PREFIX = "invariant_assertion_failure_"
 
 
 def die(message: str) -> None:
@@ -40,7 +42,14 @@ def normalize_invariant_name(value: str) -> str:
     match = QUALIFIED_EVENT_RE.match(name)
     if match:
         name = match.group("name")
-    return TRAILING_PARAMS_RE.sub("", name)
+    name = TRAILING_PARAMS_RE.sub("", name)
+    # Assertion handlers are named "..._ASSERTION_<ID>" while Foundry wrappers
+    # use "invariant_assertion_failure_<handler>"; collapse both to the
+    # canonical cross-fuzzer assertion identifier (target function name).
+    if name.startswith(FOUNDRY_ASSERTION_WRAPPER_PREFIX):
+        name = name[len(FOUNDRY_ASSERTION_WRAPPER_PREFIX) :]
+    name = ASSERTION_SUFFIX_RE.sub("", name)
+    return name.strip()
 
 
 @dataclass(frozen=True)

--- a/analysis/tests/test_invariant_overlap_report.py
+++ b/analysis/tests/test_invariant_overlap_report.py
@@ -103,6 +103,41 @@ class InvariantOverlapReportTests(unittest.TestCase):
                 ["property_previewEquivalenceFromShares"],
             )
 
+    def test_normalizes_assertion_names_for_overlap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "events.csv"
+            csv_path.write_text(
+                "\n".join(
+                    [
+                        "run_id,instance_id,fuzzer,event,elapsed_seconds",
+                        (
+                            "1,i-e,echidna,"
+                            "iHub_mintFeeShares_ASSERTION_PPS_CHANGE(uint256),10"
+                        ),
+                        (
+                            "1,i-m,medusa,"
+                            "CryticTester.iHub_mintFeeShares(uint256),11"
+                        ),
+                        (
+                            "1,i-f,foundry,"
+                            "CryticToFoundry."
+                            "invariant_assertion_failure_iHub_mintFeeShares_ASSERTION_PPS_CHANGE(),12"
+                        ),
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            events = overlap.load_events(csv_path)
+            result = overlap.build_overlap(events, total_events=len(events))
+
+            self.assertIn(("echidna", "foundry", "medusa"), result.intersections)
+            self.assertEqual(
+                result.intersections[("echidna", "foundry", "medusa")],
+                ["iHub_mintFeeShares"],
+            )
+
     def test_detail_lines_without_limit_do_not_truncate(self):
         lines = overlap._detail_lines(
             entries=[("[1] foundry + medusa (2)", ["inv_a", "inv_b", "inv_c"])],


### PR DESCRIPTION
## Summary
- normalize assertion-style invariant names in `analysis/invariant_overlap_report.py`
- strip Foundry wrapper prefix `invariant_assertion_failure_`
- strip trailing handler suffix `_ASSERTION_<ID>` to keep canonical cross-fuzzer IDs
- add regression coverage for mixed Echidna/Medusa/Foundry assertion naming

## Testing
- `../../.venv-analysis/bin/python -m unittest analysis.tests.test_invariant_overlap_report`
- `../../.venv-analysis/bin/python -m unittest discover -s analysis/tests`
