### PR TITLE
docs(skill): set acceptance timeout to 2 minutes

### DIFF
--- a/skills/target-onboarding/SKILL.md
+++ b/skills/target-onboarding/SKILL.md
@@ -223,29 +223,29 @@ Run all:
 2. Echidna smoke run
 3. Medusa smoke run
 4. Foundry invariant smoke run
-5. 5-minute canary trial for each fuzzer
+5. 2-minute canary trial for each fuzzer
 6. Ensure `CryticToFoundry.sol` has no `test_*` repro/unit tests
 7. Canary smoke checks must fail within the smoke trial window:
    - `FOUNDRY_INVARIANT_CONTINUOUS_RUN=false forge test --match-contract CryticToFoundry --match-test invariant_canary -vv`
    - `FOUNDRY_INVARIANT_CONTINUOUS_RUN=false forge test --match-contract CryticToFoundry --match-test 'invariant_assertion_failure_assert_canary_ASSERTION_CANARY' -vv`
-8. Acceptance gate: each fuzzer must report at least 2 bugs within 5 minutes:
+8. Acceptance gate: each fuzzer must report at least 2 bugs within 2 minutes:
    - one bug for `invariant_canary` (`Canary invariant`)
    - one bug for the assertion canary (`!!! canary assertion` via `assert_canary_ASSERTION_CANARY` / `invariant_assertion_failure_assert_canary_ASSERTION_CANARY`), with canonical id `assert_canary`
 
-Suggested 5-minute commands:
+Suggested 2-minute commands:
 
 ```bash
 # Echidna
-timeout 300 echidna test/recon/CryticTester.sol --contract CryticTester --config echidna.yaml --format text --disable-slither
+timeout 120 echidna test/recon/CryticTester.sol --contract CryticTester --config echidna.yaml --format text --disable-slither
 
 # Medusa (Note: you may need to use SOLC_VERSION=0.8.30)
-timeout 300 medusa fuzz --config medusa.json --timeout 300
+timeout 120 medusa fuzz --config medusa.json --timeout 120
 
 # Foundry
-timeout 300 forge test --match-contract CryticToFoundry --match-test 'invariant_' -vv
+timeout 120 forge test --match-contract CryticToFoundry --match-test 'invariant_' -vv
 ```
 
-Completion is tied to the 5-minute 2-canary acceptance gate above.
+Completion is tied to the 2-minute 2-canary acceptance gate above.
 
 Debug-only fallback for Foundry output inspection:
 
@@ -262,7 +262,7 @@ PR description must include:
 2. recon harness source ref
 3. files copied/changed
 4. local smoke test summary
-5. 5-minute canary trial summary per fuzzer (must show both canaries found)
+5. 2-minute canary trial summary per fuzzer (must show both canaries found)
 6. canary validation summary (assertion canary + global invariant canary)
 7. exact `/start` request JSON for `scfuzzbench`
 8. any target-specific overrides and why
@@ -313,7 +313,7 @@ Done means all are true:
 4. canary assertion + canary `invariant_` global failure are present and intentionally failing
 5. no parameterized function is prefixed `invariant_` (use `global_*` for parameterized globals)
 6. naming rules are satisfied across inherited recon property contracts, not only `Properties.sol`
-7. each fuzzer reports at least 2 canary bugs (assertion + global invariant) within 5 minutes
+7. each fuzzer reports at least 2 canary bugs (assertion + global invariant) within 2 minutes
 8. exact `/start` JSON is provided
 9. PR URL is recorded in final report; include tracking issue URL only if one was explicitly requested
 10. all assertion failure reasons are constants in `Properties.sol` and all begin with `!!!`


### PR DESCRIPTION
## Summary
- update target-onboarding skill acceptance-gate timing from 5 minutes to 2 minutes
- update sample timeout commands from 300s to 120s for Echidna, Medusa, and Foundry
- align related references (validation checklist, PR checklist, completion checklist) to 2-minute trials

## Testing
- not run (docs-only change)