### PR TITLE
feat: add trial-run warning for runs with N<10 or T<24h

### DIFF
--- a/analysis/benchmark_report.py
+++ b/analysis/benchmark_report.py
@@ -7,6 +7,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -14,17 +18,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-REQUIRED_COLS = ["fuzzer", "run_id", "time_hours", "bugs_found"]
+from analysis.trial_run import format_trial_run_warning, is_trial_run
 
-MIN_RUNS_PER_FUZZER = 10
-MIN_BUDGET_HOURS = 24.0
-TRIAL_RUN_WARNING = (
-    "**Warning — trial run.** "
-    "This benchmark was executed with fewer than {n} instances per fuzzer and/or "
-    "a time budget shorter than {t}h. "
-    "Results from trial runs are meant for debugging purposes and are "
-    "not valid for extracting conclusions across different fuzzers."
-)
+REQUIRED_COLS = ["fuzzer", "run_id", "time_hours", "bugs_found"]
 REQUIRED_SAMPLE_BASE_COLS = ["fuzzer", "run_id", "instance_id", "elapsed_seconds"]
 THROUGHPUT_SAMPLE_VALUE_COLS = ["tx_per_second", "gas_per_second"]
 PROGRESS_SAMPLE_VALUE_COLS = [
@@ -38,21 +34,6 @@ PROGRESS_SAMPLE_VALUE_COLS = [
 
 def die(msg: str) -> None:
     raise SystemExit(f"error: {msg}")
-
-
-def is_trial_run(budget: float, runs_per_fuzzer: List[int]) -> bool:
-    if budget < MIN_BUDGET_HOURS:
-        return True
-    if runs_per_fuzzer and min(runs_per_fuzzer) < MIN_RUNS_PER_FUZZER:
-        return True
-    return False
-
-
-def append_trial_run_warning(lines: List[str]) -> None:
-    lines.append(
-        "> " + TRIAL_RUN_WARNING.format(n=MIN_RUNS_PER_FUZZER, t=int(MIN_BUDGET_HOURS))
-    )
-    lines.append("")
 
 
 def load_csv(path: Path) -> pd.DataFrame:
@@ -999,7 +980,8 @@ def write_report(
     lines.append(f"- Time budget: **{budget:.2f}h**")
     lines.append("")
     if is_trial_run(budget, [m.runs for m in metrics]):
-        append_trial_run_warning(lines)
+        lines.append("> " + format_trial_run_warning())
+        lines.append("")
     lines.append("## Executive summary")
     lines.append(
         "This report is derived solely from cumulative bugs-found over time across repeated runs per fuzzer. "
@@ -1116,7 +1098,8 @@ def write_no_data_report(
     lines.append(f"- Source CSV: `{csv_path}`")
     lines.append("")
     if is_trial_run(budget, []):
-        append_trial_run_warning(lines)
+        lines.append("> " + format_trial_run_warning())
+        lines.append("")
     lines.append("## No data")
     lines.append("")
     lines.append(

--- a/analysis/invariant_overlap_report.py
+++ b/analysis/invariant_overlap_report.py
@@ -7,8 +7,13 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 import re
+import sys
 import textwrap
 from typing import Dict, List, Optional, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 import matplotlib
 
@@ -18,17 +23,13 @@ from matplotlib.patches import Circle
 import numpy as np
 import pandas as pd
 
-REQUIRED_COLS = {"fuzzer", "event", "elapsed_seconds"}
-
-MIN_RUNS_PER_FUZZER = 10
-MIN_BUDGET_HOURS = 24.0
-TRIAL_RUN_WARNING = (
-    "**Warning — trial run.** "
-    "This benchmark was executed with fewer than {n} instances per fuzzer and/or "
-    "a time budget shorter than {t}h. "
-    "Results from trial runs are meant for debugging purposes and are "
-    "not valid for extracting conclusions across different fuzzers."
+from analysis.trial_run import (
+    MIN_BUDGET_HOURS,
+    MIN_RUNS_PER_FUZZER,
+    format_trial_run_warning,
 )
+
+REQUIRED_COLS = {"fuzzer", "event", "elapsed_seconds"}
 OPTIONAL_ID_COLS = ("run_id", "instance_id")
 QUALIFIED_EVENT_RE = re.compile(
     r"^(?:[A-Za-z_][A-Za-z0-9_$]*\.)+(?P<name>[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?)$"
@@ -232,9 +233,7 @@ def write_md_report(
     if runs_per_fuzzer and min(runs_per_fuzzer) < MIN_RUNS_PER_FUZZER:
         is_trial = True
     if is_trial:
-        lines.append(
-            "> " + TRIAL_RUN_WARNING.format(n=MIN_RUNS_PER_FUZZER, t=int(MIN_BUDGET_HOURS))
-        )
+        lines.append("> " + format_trial_run_warning())
         lines.append("")
 
     if not result.invariants:

--- a/analysis/trial_run.py
+++ b/analysis/trial_run.py
@@ -1,0 +1,25 @@
+"""Shared trial-run detection constants and helpers."""
+
+from typing import List
+
+MIN_RUNS_PER_FUZZER = 10
+MIN_BUDGET_HOURS = 24.0
+TRIAL_RUN_WARNING = (
+    "**Warning — trial run.** "
+    "This benchmark was executed with fewer than {n} instances per fuzzer and/or "
+    "a time budget shorter than {t}h. "
+    "Results from trial runs are meant for debugging purposes and are "
+    "not valid for extracting conclusions across different fuzzers."
+)
+
+
+def is_trial_run(budget: float, runs_per_fuzzer: List[int]) -> bool:
+    if budget < MIN_BUDGET_HOURS:
+        return True
+    if runs_per_fuzzer and min(runs_per_fuzzer) < MIN_RUNS_PER_FUZZER:
+        return True
+    return False
+
+
+def format_trial_run_warning() -> str:
+    return TRIAL_RUN_WARNING.format(n=MIN_RUNS_PER_FUZZER, t=int(MIN_BUDGET_HOURS))

--- a/scripts/generate_docs_site.py
+++ b/scripts/generate_docs_site.py
@@ -13,6 +13,15 @@ import sys
 import time
 from dataclasses import dataclass
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from analysis.trial_run import (  # noqa: E402
+    MIN_BUDGET_HOURS,
+    MIN_RUNS_PER_FUZZER,
+    format_trial_run_warning,
+)
+
 
 RUN_MANIFEST_RE = re.compile(r"^runs/([0-9]+)/([0-9a-f]{32})/manifest\.json$")
 PRICING_API_REGION = "us-east-1"
@@ -703,22 +712,17 @@ def main() -> int:
 
         instances = m.get("instances_per_fuzzer")
         is_trial = False
-        if r.timeout_hours < 24:
+        if r.timeout_hours < MIN_BUDGET_HOURS:
             is_trial = True
         if instances is not None:
             try:
-                if int(instances) < 10:
+                if int(instances) < MIN_RUNS_PER_FUZZER:
                     is_trial = True
             except (TypeError, ValueError):
                 pass
         if is_trial:
             lines.append("::: warning Trial run")
-            lines.append(
-                "This benchmark was executed with fewer than 10 instances per fuzzer and/or "
-                "a time budget shorter than 24h. "
-                "Results from trial runs are meant for debugging purposes and are "
-                "not valid for extracting conclusions across different fuzzers."
-            )
+            lines.append(format_trial_run_warning())
             lines.append(":::")
             lines.append("")
 


### PR DESCRIPTION
## Summary

Closes #105.

- Adds a prominent warning banner to analysis reports and docs pages when a benchmark run has fewer than 10 instances per fuzzer (`N<10`) or a time budget under 24 hours (`T<24h`)
- These runs are trial runs meant for debugging purposes and not valid for extracting conclusions across different fuzzers
- Warning appears in three places:
  - `REPORT.md` (generated by `benchmark_report.py`)
  - `broken_invariants.md` (generated by `invariant_overlap_report.py`)
  - Per-run VitePress docs pages (generated by `generate_docs_site.py`)

## Test plan

- [x] All 14 existing tests pass (`test_benchmark_report.py`, `test_invariant_overlap_report.py`, `test_generate_docs_site.py`)
- [x] Python syntax check passes for all modified files
- [ ] Verify warning renders correctly in a trial run report (N<10 or T<24h)
- [ ] Verify no warning appears for full benchmark runs (N>=10 and T>=24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)