### PR TITLE
feat(analysis): add Mann-Whitney U test to benchmark reports

### DIFF
--- a/analysis/benchmark_report.py
+++ b/analysis/benchmark_report.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import csv
+import itertools
 import math
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
@@ -17,6 +18,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from scipy import stats
 
 from analysis.trial_run import format_trial_run_warning, is_trial_run
 
@@ -129,6 +131,20 @@ class FuzzerMetrics:
     success_rate_k: Dict[int, float]
     final_p50: int
     final_iqr: float
+    final_values: np.ndarray = None  # type: ignore[assignment]
+
+
+@dataclass
+class PairwiseResult:
+    fuzzer_a: str
+    fuzzer_b: str
+    u_stat: float
+    p_value: float
+    p_corrected: float
+    significant: bool
+    direction: str
+    median_a: float
+    median_b: float
 
 
 @dataclass
@@ -782,6 +798,7 @@ def compute_metrics(
                 success_rate_k=success_rate_k,
                 final_p50=final_p50,
                 final_iqr=final_iqr,
+                final_values=final_values,
             )
         )
     return metrics
@@ -936,6 +953,195 @@ def plot_plateau_and_late_share(
     plt.close()
 
 
+def compute_statistical_tests(
+    metrics: List[FuzzerMetrics], alpha: float = 0.05
+) -> Tuple[List[PairwiseResult], List[str]]:
+    results: List[PairwiseResult] = []
+    warn: List[str] = []
+
+    if len(metrics) < 2:
+        warn.append("Only one fuzzer present; skipping pairwise statistical tests.")
+        return results, warn
+
+    small_sample = False
+    for m in metrics:
+        if m.final_values is not None and len(m.final_values) < 5:
+            small_sample = True
+
+    if small_sample:
+        warn.append(
+            "One or more fuzzers have fewer than 5 runs. "
+            "Statistical power may be limited."
+        )
+
+    pairs = list(itertools.combinations(metrics, 2))
+    n_comparisons = len(pairs)
+
+    for m_a, m_b in pairs:
+        a = m_a.final_values
+        b = m_b.final_values
+
+        if a is None or b is None or len(a) < 2 or len(b) < 2:
+            warn.append(
+                f"Skipping {m_a.fuzzer} vs {m_b.fuzzer}: fewer than 2 runs."
+            )
+            continue
+
+        median_a = float(np.median(a))
+        median_b = float(np.median(b))
+
+        # Identical constant arrays: scipy raises ValueError
+        if np.array_equal(a, b) or (np.all(a == a[0]) and np.all(b == b[0]) and a[0] == b[0]):
+            results.append(
+                PairwiseResult(
+                    fuzzer_a=m_a.fuzzer,
+                    fuzzer_b=m_b.fuzzer,
+                    u_stat=float(len(a) * len(b)) / 2.0,
+                    p_value=1.0,
+                    p_corrected=1.0,
+                    significant=False,
+                    direction="=",
+                    median_a=median_a,
+                    median_b=median_b,
+                )
+            )
+            continue
+
+        u_stat, p_value = stats.mannwhitneyu(a, b, alternative="two-sided")
+        p_corrected = min(p_value * n_comparisons, 1.0)
+        significant = p_corrected < alpha
+
+        if median_a > median_b:
+            direction = ">"
+        elif median_a < median_b:
+            direction = "<"
+        else:
+            direction = "="
+
+        results.append(
+            PairwiseResult(
+                fuzzer_a=m_a.fuzzer,
+                fuzzer_b=m_b.fuzzer,
+                u_stat=float(u_stat),
+                p_value=float(p_value),
+                p_corrected=float(p_corrected),
+                significant=significant,
+                direction=direction,
+                median_a=median_a,
+                median_b=median_b,
+            )
+        )
+
+    return results, warn
+
+
+def format_statistical_report(
+    results: List[PairwiseResult],
+    warnings_list: List[str],
+    alpha: float = 0.05,
+) -> List[str]:
+    lines: List[str] = []
+    lines.append("## Statistical comparison (Mann-Whitney U test)")
+    lines.append("")
+
+    n_comparisons = len(results)
+    lines.append(
+        "Pairwise Mann-Whitney U tests on end-of-budget bug counts (two-sided)."
+    )
+    lines.append(
+        f"Bonferroni correction applied for {n_comparisons} comparison(s). "
+        f"Significance level: alpha = {alpha}."
+    )
+    lines.append("")
+
+    if warnings_list:
+        for w in warnings_list:
+            lines.append(f"**Warning:** {w}")
+        lines.append("")
+
+    if results:
+        header = [
+            "Fuzzer A",
+            "Fuzzer B",
+            "Median A",
+            "Median B",
+            "U statistic",
+            "p-value",
+            "p (corrected)",
+            "Significant",
+        ]
+        lines.append("| " + " | ".join(header) + " |")
+        lines.append("|" + "|".join(["---"] * len(header)) + "|")
+        for r in results:
+            med_a = (
+                str(int(r.median_a))
+                if r.median_a == int(r.median_a)
+                else f"{r.median_a:.1f}"
+            )
+            med_b = (
+                str(int(r.median_b))
+                if r.median_b == int(r.median_b)
+                else f"{r.median_b:.1f}"
+            )
+            sig_str = "yes" if r.significant else "no"
+            lines.append(
+                f"| {r.fuzzer_a} | {r.fuzzer_b} | {med_a} | {med_b} "
+                f"| {r.u_stat:.1f} | {r.p_value:.4f} | {r.p_corrected:.4f} | {sig_str} |"
+            )
+        lines.append("")
+
+        significant_results = [r for r in results if r.significant]
+        if significant_results:
+            lines.append("**Conclusions:**")
+            lines.append("")
+            for r in significant_results:
+                med_a = (
+                    str(int(r.median_a))
+                    if r.median_a == int(r.median_a)
+                    else f"{r.median_a:.1f}"
+                )
+                med_b = (
+                    str(int(r.median_b))
+                    if r.median_b == int(r.median_b)
+                    else f"{r.median_b:.1f}"
+                )
+                if r.direction == ">":
+                    lines.append(
+                        f"- With p < {alpha}, {r.fuzzer_a} finds significantly more bugs "
+                        f"than {r.fuzzer_b} (median {med_a} vs {med_b})."
+                    )
+                elif r.direction == "<":
+                    lines.append(
+                        f"- With p < {alpha}, {r.fuzzer_b} finds significantly more bugs "
+                        f"than {r.fuzzer_a} (median {med_b} vs {med_a})."
+                    )
+                else:
+                    lines.append(
+                        f"- With p < {alpha}, {r.fuzzer_a} and {r.fuzzer_b} differ significantly "
+                        f"(both median {med_a}), likely due to distributional differences."
+                    )
+            lines.append("")
+        else:
+            lines.append(
+                "No pairwise comparison reached significance after Bonferroni correction."
+            )
+            lines.append("")
+
+    lines.append(
+        "> **Note:** The Mann-Whitney U test assesses whether one fuzzer tends to find"
+    )
+    lines.append(
+        "> more bugs than another across runs. It does not measure effect size or"
+    )
+    lines.append(
+        "> practical importance. Small sample sizes (fewer than 5 runs) reduce"
+    )
+    lines.append("> statistical power.")
+    lines.append("")
+
+    return lines
+
+
 def fmt_time(value: float) -> str:
     if not math.isfinite(value):
         return "inf"
@@ -950,6 +1156,9 @@ def write_report(
     outpath: Path,
     throughput_by_fuzzer: Dict[str, ThroughputSummary] | None = None,
     progress_metrics_by_fuzzer: Dict[str, ProgressMetricsSummary] | None = None,
+    stat_results: Optional[List[PairwiseResult]] = None,
+    stat_warnings: Optional[List[str]] = None,
+    alpha: float = 0.05,
 ) -> None:
     lines: List[str] = []
     lines.append("# Fuzzer Benchmark Report (from bug-count CSV)")
@@ -1030,6 +1239,13 @@ def write_report(
         progress_metrics_by_fuzzer or {},
         fuzzer_order=[metric.fuzzer for metric in metrics],
     )
+
+    if stat_results is not None:
+        lines.extend(
+            format_statistical_report(
+                stat_results, stat_warnings or [], alpha=alpha
+            )
+        )
 
     lines.append("## Shape-based interpretation (rules of thumb)")
     lines.append(
@@ -1272,6 +1488,7 @@ def main() -> int:
     df_grid = resample_to_grid(df, grid)
     metrics = compute_metrics(df_grid, budget=budget, checkpoints=checkpoints, ks=ks)
     metrics = sorted(metrics, key=lambda m: (m.final_p50, m.auc_norm), reverse=True)
+    stat_results, stat_warnings = compute_statistical_tests(metrics)
 
     label_map = None
     if args.anonymize:
@@ -1308,6 +1525,8 @@ def main() -> int:
         outpath=report_outdir / "REPORT.md",
         throughput_by_fuzzer=throughput_by_fuzzer,
         progress_metrics_by_fuzzer=progress_metrics_by_fuzzer,
+        stat_results=stat_results,
+        stat_warnings=stat_warnings,
     )
 
     print(f"wrote: {report_outdir / 'REPORT.md'}")

--- a/analysis/requirements.txt
+++ b/analysis/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib>=3.7.0
 numpy>=1.24.0
 pandas>=2.0.0
+scipy>=1.10.0

--- a/analysis/tests/test_benchmark_report.py
+++ b/analysis/tests/test_benchmark_report.py
@@ -4,7 +4,30 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import numpy as np
+
 from analysis import benchmark_report
+
+
+def _make_metrics(fuzzer, final_values, runs=None, **kwargs):
+    vals = np.array(final_values, dtype=float)
+    defaults = dict(
+        fuzzer=fuzzer,
+        runs=runs if runs is not None else len(vals),
+        bugs_p50_t={1.0: int(np.median(vals))},
+        bugs_p25_t={1.0: int(np.percentile(vals, 25))},
+        bugs_p75_t={1.0: int(np.percentile(vals, 75))},
+        auc_norm=0.5,
+        plateau_time=0.5,
+        late_share=0.1,
+        time_to_k_p50={1: 0.5},
+        success_rate_k={1: 1.0},
+        final_p50=int(np.median(vals)),
+        final_iqr=float(np.percentile(vals, 75) - np.percentile(vals, 25)),
+        final_values=vals,
+    )
+    defaults.update(kwargs)
+    return benchmark_report.FuzzerMetrics(**defaults)
 
 
 class BenchmarkReportTests(unittest.TestCase):
@@ -309,6 +332,149 @@ class BenchmarkReportTests(unittest.TestCase):
             self.assertTrue((out_dir / "corpus_size_over_time.png").exists())
             self.assertTrue((out_dir / "favored_items_over_time.png").exists())
             self.assertTrue((out_dir / "failure_rate_over_time.png").exists())
+
+
+class StatisticalTestsTests(unittest.TestCase):
+    def test_significant_difference(self):
+        m_a = _make_metrics("echidna", [7, 8, 7, 8, 7, 8, 7, 8, 7, 8])
+        m_b = _make_metrics("medusa", [2, 3, 3, 2, 3, 2, 3, 2, 3, 2])
+        results, warnings = benchmark_report.compute_statistical_tests([m_a, m_b])
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].significant)
+        self.assertEqual(results[0].direction, ">")
+        self.assertLess(results[0].p_corrected, 0.05)
+
+    def test_identical_distributions(self):
+        vals = [5, 5, 5, 5, 5]
+        m_a = _make_metrics("fuzzer_a", vals)
+        m_b = _make_metrics("fuzzer_b", vals)
+        results, warnings = benchmark_report.compute_statistical_tests([m_a, m_b])
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].significant)
+        self.assertEqual(results[0].p_value, 1.0)
+        self.assertEqual(results[0].direction, "=")
+
+    def test_single_fuzzer_returns_empty(self):
+        m = _make_metrics("only_one", [5, 6, 7])
+        results, warnings = benchmark_report.compute_statistical_tests([m])
+        self.assertEqual(len(results), 0)
+        self.assertTrue(any("Only one fuzzer" in w for w in warnings))
+
+    def test_small_sample_warning(self):
+        m_a = _make_metrics("a", [5, 6, 7])
+        m_b = _make_metrics("b", [3, 4, 5])
+        results, warnings = benchmark_report.compute_statistical_tests([m_a, m_b])
+        self.assertTrue(any("fewer than 5 runs" in w for w in warnings))
+
+    def test_bonferroni_correction(self):
+        m_a = _make_metrics("a", [7, 8, 7, 8, 7, 8, 7, 8])
+        m_b = _make_metrics("b", [2, 3, 2, 3, 2, 3, 2, 3])
+        m_c = _make_metrics("c", [5, 5, 5, 5, 5, 5, 5, 5])
+        results, _ = benchmark_report.compute_statistical_tests([m_a, m_b, m_c])
+        # 3 pairwise comparisons
+        self.assertEqual(len(results), 3)
+        for r in results:
+            # p_corrected should be p_value * 3, clamped to 1.0
+            expected = min(r.p_value * 3, 1.0)
+            self.assertAlmostEqual(r.p_corrected, expected, places=10)
+
+    def test_fewer_than_2_runs_skipped(self):
+        m_a = _make_metrics("a", [5])
+        m_b = _make_metrics("b", [3, 4, 5])
+        results, warnings = benchmark_report.compute_statistical_tests([m_a, m_b])
+        self.assertEqual(len(results), 0)
+        self.assertTrue(any("fewer than 2 runs" in w for w in warnings))
+
+    def test_natural_language_conclusions(self):
+        m_a = _make_metrics("echidna", [7, 8, 7, 8, 7, 8, 7, 8, 7, 8])
+        m_b = _make_metrics("medusa", [2, 3, 3, 2, 3, 2, 3, 2, 3, 2])
+        results, warnings = benchmark_report.compute_statistical_tests([m_a, m_b])
+        lines = benchmark_report.format_statistical_report(results, warnings)
+        text = "\n".join(lines)
+        self.assertIn("echidna finds significantly more bugs than medusa", text)
+
+    def test_no_significant_fallback_text(self):
+        m_a = _make_metrics("a", [5, 5, 5, 5, 5])
+        m_b = _make_metrics("b", [5, 5, 5, 5, 5])
+        results, warnings = benchmark_report.compute_statistical_tests([m_a, m_b])
+        lines = benchmark_report.format_statistical_report(results, warnings)
+        text = "\n".join(lines)
+        self.assertIn("No pairwise comparison reached significance", text)
+
+    def test_write_report_integration(self):
+        m_a = _make_metrics("echidna", [7, 8, 7, 8, 7, 8, 7, 8, 7, 8])
+        m_b = _make_metrics("medusa", [2, 3, 3, 2, 3, 2, 3, 2, 3, 2])
+        results, warnings = benchmark_report.compute_statistical_tests([m_a, m_b])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            outpath = Path(tmp) / "REPORT.md"
+            benchmark_report.write_report(
+                metrics=[m_a, m_b],
+                budget=1.0,
+                checkpoints=[1.0],
+                ks=[1],
+                outpath=outpath,
+                stat_results=results,
+                stat_warnings=warnings,
+            )
+            report = outpath.read_text(encoding="utf-8")
+            self.assertIn("## Statistical comparison (Mann-Whitney U test)", report)
+            self.assertIn("Mann-Whitney U test assesses", report)
+            # Should appear after Milestones and before Shape-based
+            milestones_pos = report.index("## Milestones")
+            stat_pos = report.index("## Statistical comparison")
+            shape_pos = report.index("## Shape-based interpretation")
+            self.assertLess(milestones_pos, stat_pos)
+            self.assertLess(stat_pos, shape_pos)
+
+    def test_write_report_no_stat_section_when_none(self):
+        m = _make_metrics("foundry", [1])
+        with tempfile.TemporaryDirectory() as tmp:
+            outpath = Path(tmp) / "REPORT.md"
+            benchmark_report.write_report(
+                metrics=[m],
+                budget=1.0,
+                checkpoints=[1.0],
+                ks=[1],
+                outpath=outpath,
+            )
+            report = outpath.read_text(encoding="utf-8")
+            self.assertNotIn("## Statistical comparison", report)
+
+    def test_cli_end_to_end_with_stats(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            csv_path = tmp_dir / "cumulative.csv"
+            rows = ["fuzzer,run_id,time_hours,bugs_found"]
+            for i in range(1, 6):
+                rows.append(f"echidna,run-{i},0,0")
+                rows.append(f"echidna,run-{i},1,{6 + i}")
+                rows.append(f"medusa,run-{i},0,0")
+                rows.append(f"medusa,run-{i},1,{i}")
+            csv_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+            out_dir = tmp_dir / "out"
+            script = Path(__file__).resolve().parents[1] / "benchmark_report.py"
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    str(script),
+                    "--csv",
+                    str(csv_path),
+                    "--outdir",
+                    str(out_dir),
+                    "--budget",
+                    "1",
+                    "--checkpoints",
+                    "1",
+                    "--ks",
+                    "1",
+                ]
+            )
+            report = (out_dir / "REPORT.md").read_text(encoding="utf-8")
+            self.assertIn("## Statistical comparison (Mann-Whitney U test)", report)
+            self.assertIn("echidna", report)
+            self.assertIn("medusa", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds pairwise Mann-Whitney U tests on end-of-budget bug counts to benchmark reports, so reports can conclude e.g. "with p < 0.05, echidna finds significantly more bugs than medusa (median 7 vs 3)"
- Adds `scipy>=1.10.0` dependency, `PairwiseResult` dataclass, `compute_statistical_tests()` and `format_statistical_report()` functions
- Handles edge cases: single fuzzer, <2 runs, <5 runs warning, identical constant arrays, Bonferroni correction
- New report section placed after Milestones/Throughput/Progress metrics, before Shape-based interpretation

Closes #107

## Test plan

- [x] All 40 existing + new tests pass (`python -m pytest analysis/tests/ -v`)
- [ ] Manual: run with a multi-fuzzer cumulative CSV and verify REPORT.md contains the new statistical comparison section

🤖 Generated with [Claude Code](https://claude.com/claude-code)