### PR TITLE
Remove low-value additional metrics charts

### DIFF
--- a/analysis/benchmark_report.py
+++ b/analysis/benchmark_report.py
@@ -27,8 +27,6 @@ PROGRESS_SAMPLE_VALUE_COLS = [
     "seq_per_second",
     "coverage_proxy",
     "corpus_size",
-    "favored_items",
-    "failure_rate",
 ]
 
 
@@ -380,7 +378,7 @@ def append_progress_metrics_section(
 
     lines.append("## Progress metrics from logs (fuzzer-specific proxies)")
     lines.append(
-        "Coverage/corpus/favored/failure-rate values are parsed from each fuzzer's native progress output and are useful for trend context, not strict cross-fuzzer equivalence."
+        "Coverage/corpus values are parsed from each fuzzer's native progress output and are useful for trend context, not strict cross-fuzzer equivalence."
     )
     header = [
         "Fuzzer",
@@ -391,10 +389,6 @@ def append_progress_metrics_section(
         "Coverage p50 [p25,p75]",
         "Corpus runs",
         "Corpus p50 [p25,p75]",
-        "Favored runs",
-        "Favored p50 [p25,p75]",
-        "Failure-rate runs",
-        "Failure-rate p50 [p25,p75]",
     ]
     lines.append("| " + " | ".join(header) + " |")
     lines.append("|" + "|".join(["---"] * len(header)) + "|")
@@ -424,126 +418,11 @@ def append_progress_metrics_section(
                     fmt_triplet(row.coverage_p50, row.coverage_p25, row.coverage_p75),
                     str(row.corpus_runs),
                     fmt_triplet(row.corpus_p50, row.corpus_p25, row.corpus_p75),
-                    str(row.favored_runs),
-                    fmt_triplet(row.favored_p50, row.favored_p25, row.favored_p75),
-                    str(row.failure_rate_runs),
-                    fmt_pct_triplet(
-                        row.failure_rate_p50,
-                        row.failure_rate_p25,
-                        row.failure_rate_p75,
-                    ),
                 ]
             )
             + " |"
         )
     lines.append("")
-
-
-def plot_progress_metrics_levels(
-    progress_metrics_by_fuzzer: Dict[str, ProgressMetricsSummary],
-    outpath: Path,
-    label_map: dict[str, str] | None,
-) -> None:
-    if not progress_metrics_by_fuzzer:
-        return
-
-    ordered = sorted(progress_metrics_by_fuzzer.keys())
-    fig, axes = plt.subplots(3, 2, figsize=(12, 10))
-    axes_flat = list(axes.flatten())
-
-    metric_specs = [
-        ("Seq/s (p50, IQR)", "seqps_p50", "seqps_p25", "seqps_p75", 1.0),
-        ("Coverage proxy (p50, IQR)", "coverage_p50", "coverage_p25", "coverage_p75", 1.0),
-        ("Corpus size (p50, IQR)", "corpus_p50", "corpus_p25", "corpus_p75", 1.0),
-        ("Favored items (p50, IQR)", "favored_p50", "favored_p25", "favored_p75", 1.0),
-        ("Failure rate % (p50, IQR)", "failure_rate_p50", "failure_rate_p25", "failure_rate_p75", 100.0),
-    ]
-
-    for idx, (title, p50_key, p25_key, p75_key, factor) in enumerate(metric_specs):
-        ax = axes_flat[idx]
-        labels: List[str] = []
-        values: List[float] = []
-        lower: List[float] = []
-        upper: List[float] = []
-        for fuzzer in ordered:
-            row = progress_metrics_by_fuzzer[fuzzer]
-            p50 = getattr(row, p50_key)
-            if p50 is None:
-                continue
-            p25 = getattr(row, p25_key)
-            p75 = getattr(row, p75_key)
-            if p25 is None:
-                p25 = p50
-            if p75 is None:
-                p75 = p50
-            labels.append(label_map.get(fuzzer, fuzzer) if label_map else fuzzer)
-            values.append(p50 * factor)
-            lower.append(max(0.0, (p50 - p25) * factor))
-            upper.append(max(0.0, (p75 - p50) * factor))
-
-        if not values:
-            ax.axis("off")
-            ax.text(0.5, 0.5, "n/a", ha="center", va="center")
-            ax.set_title(title)
-            continue
-
-        x = np.arange(len(values))
-        ax.bar(x, values, color="#5A7D9A", alpha=0.9)
-        ax.errorbar(
-            x,
-            values,
-            yerr=[lower, upper],
-            fmt="none",
-            ecolor="black",
-            capsize=3,
-            elinewidth=1.0,
-        )
-        ax.set_xticks(x)
-        ax.set_xticklabels(labels, rotation=20, ha="right")
-        ax.set_title(title)
-
-    for idx in range(len(metric_specs), len(axes_flat)):
-        axes_flat[idx].axis("off")
-
-    fig.suptitle("Progress metrics by fuzzer")
-    fig.tight_layout(rect=[0, 0, 1, 0.97])
-    fig.savefig(outpath, dpi=200)
-    plt.close(fig)
-
-
-def plot_progress_metrics_availability(
-    progress_metrics_by_fuzzer: Dict[str, ProgressMetricsSummary],
-    outpath: Path,
-    label_map: dict[str, str] | None,
-) -> None:
-    if not progress_metrics_by_fuzzer:
-        return
-
-    ordered = sorted(progress_metrics_by_fuzzer.keys())
-    labels = [label_map.get(fuzzer, fuzzer) if label_map else fuzzer for fuzzer in ordered]
-    x = np.arange(len(ordered))
-    metric_specs = [
-        ("Seq/s", "seqps_runs"),
-        ("Coverage", "coverage_runs"),
-        ("Corpus", "corpus_runs"),
-        ("Favored", "favored_runs"),
-        ("Failure rate", "failure_rate_runs"),
-    ]
-    width = 0.8 / len(metric_specs)
-
-    plt.figure(figsize=(10, 5))
-    for idx, (name, attr) in enumerate(metric_specs):
-        vals = [float(getattr(progress_metrics_by_fuzzer[fuzzer], attr)) for fuzzer in ordered]
-        offset = (idx - (len(metric_specs) - 1) / 2.0) * width
-        plt.bar(x + offset, vals, width=width, label=name)
-
-    plt.xticks(x, labels)
-    plt.ylabel("Runs with metric samples")
-    plt.title("Progress metric availability by fuzzer")
-    plt.legend(ncol=3)
-    plt.tight_layout()
-    plt.savefig(outpath, dpi=200)
-    plt.close()
 
 
 def nan_percentile_rows(arr: np.ndarray, percentile_value: float) -> np.ndarray:
@@ -669,20 +548,6 @@ def plot_sample_metric_charts(
             "Corpus size over time",
             "Corpus size",
             1.0,
-        ),
-        (
-            "favored_items",
-            "favored_items_over_time.png",
-            "Favored items over time",
-            "Favored items",
-            1.0,
-        ),
-        (
-            "failure_rate",
-            "failure_rate_over_time.png",
-            "Failure rate over time",
-            "Failure rate (%)",
-            100.0,
         ),
     ]
     for value_column, filename, title, ylabel, scale in progress_specs:
@@ -1246,17 +1111,6 @@ def main() -> int:
             images_outdir / "plateau_and_late_share.png",
             msg,
         )
-        if progress_metrics_by_fuzzer:
-            plot_progress_metrics_levels(
-                progress_metrics_by_fuzzer,
-                images_outdir / "progress_metrics_levels.png",
-                label_map=None,
-            )
-            plot_progress_metrics_availability(
-                progress_metrics_by_fuzzer,
-                images_outdir / "progress_metrics_availability.png",
-                label_map=None,
-            )
         sample_metric_plot_files = plot_sample_metric_charts(
             throughput_samples_df=throughput_samples_df,
             progress_metrics_samples_df=progress_metrics_samples_df,
@@ -1282,17 +1136,6 @@ def main() -> int:
     plot_time_to_k(metrics, ks=ks, outpath=images_outdir / "time_to_k.png", label_map=label_map)
     plot_final_distribution(df_grid, images_outdir / "final_distribution.png", label_map)
     plot_plateau_and_late_share(metrics, images_outdir / "plateau_and_late_share.png", label_map)
-    if progress_metrics_by_fuzzer:
-        plot_progress_metrics_levels(
-            progress_metrics_by_fuzzer,
-            images_outdir / "progress_metrics_levels.png",
-            label_map=label_map,
-        )
-        plot_progress_metrics_availability(
-            progress_metrics_by_fuzzer,
-            images_outdir / "progress_metrics_availability.png",
-            label_map=label_map,
-        )
     sample_metric_plot_files = plot_sample_metric_charts(
         throughput_samples_df=throughput_samples_df,
         progress_metrics_samples_df=progress_metrics_samples_df,
@@ -1317,13 +1160,6 @@ def main() -> int:
         "final_distribution.png",
         "plateau_and_late_share.png",
     ]
-    if progress_metrics_by_fuzzer:
-        plot_files.extend(
-            [
-                "progress_metrics_levels.png",
-                "progress_metrics_availability.png",
-            ]
-        )
     plot_files.extend(sample_metric_plot_files)
     print("plots: " + ", ".join(plot_files))
     return 0

--- a/analysis/tests/test_benchmark_report.py
+++ b/analysis/tests/test_benchmark_report.py
@@ -134,9 +134,11 @@ class BenchmarkReportTests(unittest.TestCase):
 
             self.assertIn("Progress metrics from logs", report)
             self.assertIn(
-                "| foundry | 1 | 0 | n/a | 1 | 280.00 [260.00,300.00] | 1 | 85.00 [80.00,90.00] | 1 | 66.00 [60.00,70.00] | 1 | 25.0% [20.0%,30.0%] |",
+                "| foundry | 1 | 0 | n/a | 1 | 280.00 [260.00,300.00] | 1 | 85.00 [80.00,90.00] |",
                 report,
             )
+            self.assertNotIn("Favored", report)
+            self.assertNotIn("Failure-rate", report)
 
     def test_cli_clamps_checkpoints_to_budget(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -228,8 +230,8 @@ class BenchmarkReportTests(unittest.TestCase):
             self.assertIn("## No data", report)
             self.assertIn("## Throughput metrics (if supported by log format)", report)
             self.assertIn("## Progress metrics from logs (fuzzer-specific proxies)", report)
-            self.assertTrue((out_dir / "progress_metrics_levels.png").exists())
-            self.assertTrue((out_dir / "progress_metrics_availability.png").exists())
+            self.assertFalse((out_dir / "progress_metrics_levels.png").exists())
+            self.assertFalse((out_dir / "progress_metrics_availability.png").exists())
 
     def test_cli_generates_metric_timeseries_charts_from_samples(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -268,11 +270,11 @@ class BenchmarkReportTests(unittest.TestCase):
             progress_samples_csv.write_text(
                 "\n".join(
                     [
-                        "run_id,instance_id,fuzzer,fuzzer_label,elapsed_seconds,seq_per_second,coverage_proxy,corpus_size,favored_items,failure_rate,source,log_path",
-                        "run-1,i-1,foundry,foundry,0,5,100,50,20,0.10,text-metrics,a.log",
-                        "run-1,i-1,foundry,foundry,3600,6,130,70,24,0.05,text-metrics,a.log",
-                        "run-1,i-2,foundry,foundry,0,4,90,45,18,0.12,text-metrics,b.log",
-                        "run-1,i-2,foundry,foundry,3600,5,120,66,22,0.06,text-metrics,b.log",
+                        "run_id,instance_id,fuzzer,fuzzer_label,elapsed_seconds,seq_per_second,coverage_proxy,corpus_size,source,log_path",
+                        "run-1,i-1,foundry,foundry,0,5,100,50,text-metrics,a.log",
+                        "run-1,i-1,foundry,foundry,3600,6,130,70,text-metrics,a.log",
+                        "run-1,i-2,foundry,foundry,0,4,90,45,text-metrics,b.log",
+                        "run-1,i-2,foundry,foundry,3600,5,120,66,text-metrics,b.log",
                     ]
                 )
                 + "\n",
@@ -307,8 +309,8 @@ class BenchmarkReportTests(unittest.TestCase):
             self.assertTrue((out_dir / "seq_per_second_over_time.png").exists())
             self.assertTrue((out_dir / "coverage_proxy_over_time.png").exists())
             self.assertTrue((out_dir / "corpus_size_over_time.png").exists())
-            self.assertTrue((out_dir / "favored_items_over_time.png").exists())
-            self.assertTrue((out_dir / "failure_rate_over_time.png").exists())
+            self.assertFalse((out_dir / "favored_items_over_time.png").exists())
+            self.assertFalse((out_dir / "failure_rate_over_time.png").exists())
 
 
 if __name__ == "__main__":

--- a/scripts/generate_docs_site.py
+++ b/scripts/generate_docs_site.py
@@ -739,19 +739,11 @@ def main() -> int:
         progress_metrics_summary_csv_key = (
             f"{r.analysis_prefix}/progress_metrics_summary.csv"
         )
-        progress_metrics_levels_chart_key = (
-            f"{r.analysis_prefix}/progress_metrics_levels.png"
-        )
-        progress_metrics_availability_chart_key = (
-            f"{r.analysis_prefix}/progress_metrics_availability.png"
-        )
         txps_over_time_chart_key = f"{r.analysis_prefix}/tx_per_second_over_time.png"
         gasps_over_time_chart_key = f"{r.analysis_prefix}/gas_per_second_over_time.png"
         seqps_over_time_chart_key = f"{r.analysis_prefix}/seq_per_second_over_time.png"
         coverage_over_time_chart_key = f"{r.analysis_prefix}/coverage_proxy_over_time.png"
         corpus_over_time_chart_key = f"{r.analysis_prefix}/corpus_size_over_time.png"
-        favored_over_time_chart_key = f"{r.analysis_prefix}/favored_items_over_time.png"
-        failure_over_time_chart_key = f"{r.analysis_prefix}/failure_rate_over_time.png"
         runner_md_key = f"{r.analysis_prefix}/runner_resource_usage.md"
         runner_summary_csv_key = f"{r.analysis_prefix}/runner_resource_summary.csv"
         runner_timeseries_csv_key = f"{r.analysis_prefix}/runner_resource_timeseries.csv"
@@ -778,14 +770,6 @@ def main() -> int:
             r.analysis_kind == "analysis"
             and head_exists(bucket, progress_metrics_summary_csv_key, profile=profile)
         )
-        has_progress_metrics_levels_chart = (
-            r.analysis_kind == "analysis"
-            and head_exists(bucket, progress_metrics_levels_chart_key, profile=profile)
-        )
-        has_progress_metrics_availability_chart = (
-            r.analysis_kind == "analysis"
-            and head_exists(bucket, progress_metrics_availability_chart_key, profile=profile)
-        )
         has_txps_over_time_chart = (
             r.analysis_kind == "analysis"
             and head_exists(bucket, txps_over_time_chart_key, profile=profile)
@@ -805,14 +789,6 @@ def main() -> int:
         has_corpus_over_time_chart = (
             r.analysis_kind == "analysis"
             and head_exists(bucket, corpus_over_time_chart_key, profile=profile)
-        )
-        has_favored_over_time_chart = (
-            r.analysis_kind == "analysis"
-            and head_exists(bucket, favored_over_time_chart_key, profile=profile)
-        )
-        has_failure_over_time_chart = (
-            r.analysis_kind == "analysis"
-            and head_exists(bucket, failure_over_time_chart_key, profile=profile)
         )
         has_runner_md = (
             r.analysis_kind == "analysis" and head_exists(bucket, runner_md_key, profile=profile)
@@ -834,12 +810,6 @@ def main() -> int:
                 lines.append(f"![Time To K]({analysis_base}/time_to_k.png)")
                 lines.append(f"![Final Distribution]({analysis_base}/final_distribution.png)")
                 lines.append(f"![Plateau And Late Share]({analysis_base}/plateau_and_late_share.png)")
-                if has_progress_metrics_levels_chart:
-                    lines.append(f"![Progress Metrics Levels]({analysis_base}/progress_metrics_levels.png)")
-                if has_progress_metrics_availability_chart:
-                    lines.append(
-                        f"![Progress Metrics Availability]({analysis_base}/progress_metrics_availability.png)"
-                    )
                 if has_txps_over_time_chart:
                     lines.append(f"![Tx/s Over Time]({analysis_base}/tx_per_second_over_time.png)")
                 if has_gasps_over_time_chart:
@@ -850,10 +820,6 @@ def main() -> int:
                     lines.append(f"![Coverage Over Time]({analysis_base}/coverage_proxy_over_time.png)")
                 if has_corpus_over_time_chart:
                     lines.append(f"![Corpus Size Over Time]({analysis_base}/corpus_size_over_time.png)")
-                if has_favored_over_time_chart:
-                    lines.append(f"![Favored Items Over Time]({analysis_base}/favored_items_over_time.png)")
-                if has_failure_over_time_chart:
-                    lines.append(f"![Failure Rate Over Time]({analysis_base}/failure_rate_over_time.png)")
                 if has_invariant_chart:
                     lines.append(f"![Invariant Overlap (UpSet)]({analysis_base}/invariant_overlap_upset.png)")
                 if has_cpu_chart:


### PR DESCRIPTION
## Summary

- Remove 4 low-value/redundant charts: `progress_metrics_levels.png`, `progress_metrics_availability.png`, `favored_items_over_time.png`, `failure_rate_over_time.png`
- Trim the progress metrics table in REPORT.md to only show seq/s, coverage, corpus (remove favored_items and failure_rate columns)
- Keep the 5 most useful additional charts: tx/s, gas/s, seq/s, coverage, and corpus size over time
- Filed #112 for adding tx/gas throughput data to Foundry's log JSON output

Closes #106

## Test plan

- [x] All 29 existing tests pass (`python3 -m pytest analysis/tests/ -v`)
- [x] Removed charts are no longer generated (verified via `assertFalse` in tests)
- [x] Remaining 5 additional charts still generate correctly
- [x] Trimmed progress metrics table has correct columns (seq/s, coverage, corpus only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)