### PR TITLE
docs(target-onboarding): require one assertion constant per handler

### DIFF
--- a/skills/target-onboarding/SKILL.md
+++ b/skills/target-onboarding/SKILL.md
@@ -52,6 +52,8 @@ Optional:
    - assertion handler functions must use `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>(...)`
    - `ASSERTION_CONSTANT_SUFFIX` must exactly match the referenced `ASSERTION_*` constant suffix
      - example: `ASSERTION_WITHDRAW_DOS` -> `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS(...)`
+   - each assertion handler function must reference exactly one `ASSERTION_*` constant
+   - if a property needs multiple checks (`gte/lte/eq/t/...`) in the same handler, all checks must use that same single `ASSERTION_*` constant
    - Foundry wrappers must use `invariant_assertion_failure_targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>()`
      - example: `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS` -> `invariant_assertion_failure_iSpoke_withdraw_ASSERTION_WITHDRAW_DOS()`
    - wrapper suffix after `invariant_assertion_failure_` must exactly match the handler identifier (`targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`)
@@ -110,11 +112,12 @@ Because assertion failures can be hidden in invariant output, enforce:
 6. name assertion handlers as `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>(...)`
    - `ASSERTION_CONSTANT_SUFFIX` must exactly match the referenced `ASSERTION_*` constant suffix
    - examples: `iHub_mintFeeShares_ASSERTION_MINT_FEE_SHARES_PPS_CHANGE`, `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS`, `assert_canary_ASSERTION_CANARY`
-   - for legacy handlers that assert multiple `ASSERTION_*` constants, keep existing logic by default; if splitting or helper extraction is unclear, ask the user first
+   - each assertion handler must reference exactly one `ASSERTION_*` constant
+   - if multiple checks are required in one handler, reuse the same single `ASSERTION_*` constant across those checks
 7. add one wrapper `invariant_assertion_failure_targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>()` per assertion handler identifier
 8. wrappers must only check `assertionFailures[ASSERTION_*]` and must not trigger actions directly
 9. when a wrapper is tied to a handler identifier, wrapper suffix after `invariant_assertion_failure_` must exactly match that assertion handler identifier
-   - for legacy multi-assert handlers, additional per-assertion wrappers are allowed; if 1:1 splitting is unclear or requested, confirm with the user
+   - do not keep legacy multi-assert handlers; split/rename so every handler and wrapper pair maps to a single `ASSERTION_*`
 10. `setUp()` must include handler routing (`targetContract`, multiple `targetSender` values)
 11. do not pre-seed assertion failures in `setUp()` (no hardcoded `_recordAssertion(false, ...)`)
 12. local review must confirm canonical identifier compatibility:
@@ -310,7 +313,7 @@ Typical fields:
    - ensure `ASSERTION_CONSTANT_SUFFIX` exactly matches the referenced `ASSERTION_*` constant suffix
    - ensure Foundry wrapper is named `invariant_assertion_failure_targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`
    - ensure wrapper suffix exactly matches handler identifier so canonical id remains `targetFunctionName`
-   - for legacy multi-assert handlers, prefer behavior-preserving fixes; if split/helper choices are ambiguous, ask the user which style they want
+   - ensure each handler references exactly one `ASSERTION_*` constant; split legacy multi-assert handlers when needed
 
 ## Completion checklist
 
@@ -325,6 +328,5 @@ Done means all are true:
 8. exact `/start` JSON is provided
 9. PR URL is recorded in final report; include tracking issue URL only if one was explicitly requested
 10. all assertion failure reasons are constants in `Properties.sol` and all begin with `!!!`
-11. every assertion handler `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>` has at least one matching wrapper in `CryticToFoundry.sol`; legacy multi-assert handlers may also keep additional per-assertion wrappers without splitting handler logic
-12. when helper-method extraction or handler splitting is ambiguous, user preference was confirmed before applying structural refactors
-13. assertion failures normalize to `targetFunctionName` across Echidna, Medusa, and Foundry
+11. every assertion handler `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>` has exactly one referenced `ASSERTION_*` constant and a matching wrapper in `CryticToFoundry.sol`
+12. assertion failures normalize to `targetFunctionName` across Echidna, Medusa, and Foundry


### PR DESCRIPTION
## Summary
- add an explicit target-onboarding directive that each assertion handler must reference exactly one `ASSERTION_*` constant
- require multi-check handlers (`gte/lte/eq/t/...`) to reuse the same single assertion constant
- remove legacy guidance that allowed multi-assert handlers/wrappers

## Why
`dev-recon` reconciliation/mapping currently collapses multi-constant handlers into one Foundry invariant key. Enforcing one assertion constant per handler avoids ambiguous cross-fuzzer normalization.
