### PR TITLE
Use Echidna RTS -A1g by default in runners

### DIFF
--- a/fuzzers/README.md
+++ b/fuzzers/README.md
@@ -18,9 +18,11 @@ Environment variables:
 - `ECHIDNA_CONFIG` or `ECHIDNA_TARGET` (required; add `ECHIDNA_CONTRACT` if needed)
 - `ECHIDNA_WORKERS`, `ECHIDNA_TEST_MODE`, `ECHIDNA_EXTRA_ARGS`
 - `ECHIDNA_CORPUS_DIR`
+- `ECHIDNA_RTS_ARGS` (optional; defaults to `-A1g`; set to empty to disable RTS args)
 
 Notes:
 - In `property` mode, the runner rewrites `prefix: "invariant_"` to `prefix: "echidna_"` inside the config file so global properties are treated like assertions.
+- By default, the runner appends `+RTS -A1g -RTS` to reduce GC overhead on multicore instances.
 
 ## Echidna (symexec)
 

--- a/fuzzers/echidna-symexec/run.sh
+++ b/fuzzers/echidna-symexec/run.sh
@@ -74,6 +74,12 @@ if [[ -n "${ECHIDNA_TARGET:-}" ]]; then
   cmd+=("${ECHIDNA_TARGET}")
 fi
 
+echidna_rts_args="${ECHIDNA_RTS_ARGS:--A1g}"
+if [[ -n "${echidna_rts_args}" ]]; then
+  read -r -a rts_args <<< "${echidna_rts_args}"
+  cmd+=(+RTS "${rts_args[@]}" -RTS)
+fi
+
 set +e
 pushd "${repo_dir}" >/dev/null
 run_with_timeout "${log_file}" "${cmd[@]}"

--- a/fuzzers/echidna/run.sh
+++ b/fuzzers/echidna/run.sh
@@ -73,6 +73,12 @@ if [[ -n "${ECHIDNA_TARGET:-}" ]]; then
   cmd+=("${ECHIDNA_TARGET}")
 fi
 
+echidna_rts_args="${ECHIDNA_RTS_ARGS:--A1g}"
+if [[ -n "${echidna_rts_args}" ]]; then
+  read -r -a rts_args <<< "${echidna_rts_args}"
+  cmd+=(+RTS "${rts_args[@]}" -RTS)
+fi
+
 set +e
 pushd "${repo_dir}" >/dev/null
 run_with_timeout "${log_file}" "${cmd[@]}"


### PR DESCRIPTION
## Summary
- apply the recommendation from issue #90 to run Echidna with RTS GC tuning by default
- append `+RTS -A1g -RTS` at the end of both `echidna` and `echidna-symexec` runner commands
- add `ECHIDNA_RTS_ARGS` env override so campaigns can tune or disable RTS args
- document the new knob and default behavior in `fuzzers/README.md`

## Validation
- `bash -n fuzzers/echidna/run.sh`
- `bash -n fuzzers/echidna-symexec/run.sh`

Closes #90
