### PR TITLE
Fix deterministic fuzzer colors across benchmark charts

### DIFF
--- a/analysis/benchmark_report.py
+++ b/analysis/benchmark_report.py
@@ -21,6 +21,11 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
+from analysis.plot_palette import (
+    build_fuzzer_color_map,
+    collect_fuzzer_names,
+    non_fuzzer_shades,
+)
 from analysis.trial_run import format_trial_run_warning, is_trial_run
 
 REQUIRED_COLS = ["fuzzer", "run_id", "time_hours", "bugs_found"]
@@ -31,9 +36,6 @@ PROGRESS_SAMPLE_VALUE_COLS = [
     "coverage_proxy",
     "corpus_size",
 ]
-FUZZER_BASE_COLORS = list(plt.get_cmap("tab20").colors)
-FUZZER_COLOR_SEQUENCE = FUZZER_BASE_COLORS[::2] + FUZZER_BASE_COLORS[1::2]
-NON_FUZZER_CMAP = plt.get_cmap("Purples")
 
 
 def die(msg: str) -> None:
@@ -455,52 +457,6 @@ def nan_percentile_rows(arr: np.ndarray, percentile_value: float) -> np.ndarray:
     return out
 
 
-def collect_fuzzer_names(*frames: pd.DataFrame) -> List[str]:
-    names: List[str] = []
-    seen: set[str] = set()
-    for frame in frames:
-        if "fuzzer" not in frame.columns:
-            continue
-        for raw_name in frame["fuzzer"].dropna().astype(str):
-            name = raw_name.strip()
-            if not name or name in seen:
-                continue
-            names.append(name)
-            seen.add(name)
-    return names
-
-
-def non_fuzzer_shades(
-    count: int, *, min_shade: float = 0.45, max_shade: float = 0.9
-) -> List[tuple]:
-    if count <= 0:
-        return []
-    if count == 1:
-        return [NON_FUZZER_CMAP(max_shade)]
-    return [
-        NON_FUZZER_CMAP(
-            min_shade + (max_shade - min_shade) * (idx / float(count - 1))
-        )
-        for idx in range(count)
-    ]
-
-
-def build_fuzzer_color_map(fuzzers: List[str]) -> Dict[str, tuple]:
-    ordered_fuzzers = sorted({str(fuzzer).strip() for fuzzer in fuzzers if str(fuzzer).strip()})
-    if not ordered_fuzzers:
-        return {}
-
-    colors = list(FUZZER_COLOR_SEQUENCE[: len(ordered_fuzzers)])
-    extra = len(ordered_fuzzers) - len(colors)
-    if extra > 0:
-        hsv = plt.get_cmap("hsv")
-        for idx in range(extra):
-            hue = (idx * 0.61803398875) % 1.0
-            colors.append(hsv(hue))
-
-    return {fuzzer: colors[idx] for idx, fuzzer in enumerate(ordered_fuzzers)}
-
-
 def plot_metric_over_time(
     *,
     metric_df: pd.DataFrame,
@@ -860,7 +816,7 @@ def plot_final_distribution(
             else "#333333"
         )
 
-    boxplot = plt.boxplot(data, labels=labels, showfliers=False, patch_artist=True)
+    boxplot = plt.boxplot(data, tick_labels=labels, showfliers=False, patch_artist=True)
     for idx, color in enumerate(box_colors):
         boxplot["boxes"][idx].set_facecolor(mcolors.to_rgba(color, alpha=0.25))
         boxplot["boxes"][idx].set_edgecolor(color)
@@ -1373,7 +1329,11 @@ def main() -> int:
         else pd.DataFrame(columns=["fuzzer", "series_id", "time_hours", *PROGRESS_SAMPLE_VALUE_COLS])
     )
     fuzzer_colors = build_fuzzer_color_map(
-        collect_fuzzer_names(df, throughput_samples_df, progress_metrics_samples_df)
+        collect_fuzzer_names(
+            df["fuzzer"],
+            throughput_samples_df["fuzzer"],
+            progress_metrics_samples_df["fuzzer"],
+        )
     )
 
     if args.budget is None:

--- a/analysis/invariant_overlap_report.py
+++ b/analysis/invariant_overlap_report.py
@@ -23,6 +23,10 @@ from matplotlib.patches import Circle
 import numpy as np
 import pandas as pd
 
+from analysis.plot_palette import (
+    build_non_fuzzer_color_map,
+    non_fuzzer_shades,
+)
 from analysis.trial_run import (
     MIN_BUDGET_HOURS,
     MIN_RUNS_PER_FUZZER,
@@ -442,6 +446,11 @@ def plot_upset(result: OverlapResult, out_png: Path, *, top_k: int) -> None:
     max_height = max(float(np.max(heights)), 1.0)
     top_pad = max(0.5, max_height * 0.08)
     combo_ids = [combo_id(combo) for combo, _ in intersections]
+    purple_scale = non_fuzzer_shades(4, min_shade=0.35, max_shade=0.9)
+    inactive_dot_color = purple_scale[0]
+    set_bar_color = purple_scale[1]
+    intersection_bar_color = purple_scale[2]
+    active_dot_color = purple_scale[3]
 
     detail_entries = [
         (
@@ -493,7 +502,7 @@ def plot_upset(result: OverlapResult, out_png: Path, *, top_k: int) -> None:
     )
 
     # --- Intersection size bars (top-center) ---
-    ax_bars.bar(x, heights, color="#1f77b4")
+    ax_bars.bar(x, heights, color=intersection_bar_color)
     for idx, height in enumerate(heights):
         ax_bars.text(
             idx,
@@ -517,19 +526,19 @@ def plot_upset(result: OverlapResult, out_png: Path, *, top_k: int) -> None:
     # --- Dot matrix (bottom-center) ---
     y_ticks = np.arange(len(fuzzers), dtype=float)
     for y in y_ticks:
-        ax_matrix.scatter(x, np.full_like(x, y), color="#d0d0d0", s=60, zorder=1)
+        ax_matrix.scatter(x, np.full_like(x, y), color=inactive_dot_color, s=60, zorder=1)
 
     for xi, (combo, _) in enumerate(intersections):
         ys = sorted(y_pos[fuzzer] for fuzzer in combo)
         ax_matrix.scatter(
             np.full(len(ys), xi, dtype=float),
             np.array(ys, dtype=float),
-            color="#222222",
+            color=active_dot_color,
             s=80,
             zorder=3,
         )
         if len(ys) > 1:
-            ax_matrix.plot([xi, xi], [ys[0], ys[-1]], color="#222222", linewidth=2.0, zorder=2)
+            ax_matrix.plot([xi, xi], [ys[0], ys[-1]], color=active_dot_color, linewidth=2.0, zorder=2)
 
     ax_matrix.set_yticks(y_ticks)
     ax_matrix.set_yticklabels([])
@@ -545,7 +554,7 @@ def plot_upset(result: OverlapResult, out_png: Path, *, top_k: int) -> None:
 
     # --- Set size bars pointing left (bottom-left) ---
     set_sizes = [result.set_sizes[fuzzer] for fuzzer in fuzzers]
-    ax_sets.barh(y_ticks, set_sizes, color="#7daedb")
+    ax_sets.barh(y_ticks, set_sizes, color=set_bar_color)
     max_set_size = max(max(set_sizes), 1)
     for y, size in zip(y_ticks, set_sizes):
         ax_sets.text(
@@ -579,6 +588,7 @@ def plot_venn_like(result: OverlapResult, out_png: Path) -> None:
         return
 
     fuzzers = sorted(result.fuzzers)
+    venn_colors = build_non_fuzzer_color_map(fuzzers, min_shade=0.55, max_shade=0.9)
     n = len(fuzzers)
 
     if n == 1:
@@ -587,7 +597,7 @@ def plot_venn_like(result: OverlapResult, out_png: Path) -> None:
         gs = fig.add_gridspec(1, 2, width_ratios=[1.4, 1.2], wspace=0.15)
         ax = fig.add_subplot(gs[0, 0])
         ax_details = fig.add_subplot(gs[0, 1])
-        ax.add_patch(Circle((0.5, 0.5), 0.3, alpha=0.25, color="#1f77b4", lw=2))
+        ax.add_patch(Circle((0.5, 0.5), 0.3, alpha=0.25, color=venn_colors[fuzzer], lw=2))
         ax.text(
             0.5,
             0.5,
@@ -634,8 +644,8 @@ def plot_venn_like(result: OverlapResult, out_png: Path) -> None:
         gs = fig.add_gridspec(1, 2, width_ratios=[1.5, 1.1], wspace=0.15)
         ax = fig.add_subplot(gs[0, 0])
         ax_details = fig.add_subplot(gs[0, 1])
-        ax.add_patch(Circle((0.42, 0.5), 0.28, alpha=0.28, color="#1f77b4", lw=2))
-        ax.add_patch(Circle((0.58, 0.5), 0.28, alpha=0.28, color="#ff7f0e", lw=2))
+        ax.add_patch(Circle((0.42, 0.5), 0.28, alpha=0.28, color=venn_colors[a], lw=2))
+        ax.add_patch(Circle((0.58, 0.5), 0.28, alpha=0.28, color=venn_colors[b], lw=2))
         ax.text(0.33, 0.5, str(a_only), ha="center", va="center", fontsize=15)
         ax.text(0.67, 0.5, str(b_only), ha="center", va="center", fontsize=15)
         ax.text(0.5, 0.5, str(ab), ha="center", va="center", fontsize=15, fontweight="bold")
@@ -677,9 +687,9 @@ def plot_venn_like(result: OverlapResult, out_png: Path) -> None:
         gs = fig.add_gridspec(1, 2, width_ratios=[1.6, 1.1], wspace=0.15)
         ax = fig.add_subplot(gs[0, 0])
         ax_details = fig.add_subplot(gs[0, 1])
-        ax.add_patch(Circle((0.43, 0.58), 0.24, alpha=0.28, color="#1f77b4", lw=2))
-        ax.add_patch(Circle((0.57, 0.58), 0.24, alpha=0.28, color="#ff7f0e", lw=2))
-        ax.add_patch(Circle((0.50, 0.42), 0.24, alpha=0.28, color="#2ca02c", lw=2))
+        ax.add_patch(Circle((0.43, 0.58), 0.24, alpha=0.28, color=venn_colors[a], lw=2))
+        ax.add_patch(Circle((0.57, 0.58), 0.24, alpha=0.28, color=venn_colors[b], lw=2))
+        ax.add_patch(Circle((0.50, 0.42), 0.24, alpha=0.28, color=venn_colors[c], lw=2))
         ax.text(0.34, 0.60, str(a_only), ha="center", va="center", fontsize=13)
         ax.text(0.66, 0.60, str(b_only), ha="center", va="center", fontsize=13)
         ax.text(0.50, 0.30, str(c_only), ha="center", va="center", fontsize=13)

--- a/analysis/plot_palette.py
+++ b/analysis/plot_palette.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+import matplotlib.pyplot as plt
+
+FUZZER_BASE_COLORS = list(plt.get_cmap("tab20").colors)
+FUZZER_COLOR_SEQUENCE = FUZZER_BASE_COLORS[::2] + FUZZER_BASE_COLORS[1::2]
+NON_FUZZER_CMAP = plt.get_cmap("Purples")
+
+
+def collect_fuzzer_names(*groups: Iterable[object]) -> List[str]:
+    names: List[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for raw_name in group:
+            name = str(raw_name).strip()
+            if not name or name in seen:
+                continue
+            names.append(name)
+            seen.add(name)
+    return names
+
+
+def non_fuzzer_shades(
+    count: int, *, min_shade: float = 0.45, max_shade: float = 0.9
+) -> List[tuple]:
+    if count <= 0:
+        return []
+    if count == 1:
+        return [NON_FUZZER_CMAP(max_shade)]
+    return [
+        NON_FUZZER_CMAP(
+            min_shade + (max_shade - min_shade) * (idx / float(count - 1))
+        )
+        for idx in range(count)
+    ]
+
+
+def build_fuzzer_color_map(fuzzers: Iterable[object]) -> Dict[str, tuple]:
+    ordered_fuzzers = sorted(
+        {
+            str(fuzzer).strip()
+            for fuzzer in fuzzers
+            if str(fuzzer).strip()
+        }
+    )
+    if not ordered_fuzzers:
+        return {}
+
+    colors = list(FUZZER_COLOR_SEQUENCE[: len(ordered_fuzzers)])
+    extra = len(ordered_fuzzers) - len(colors)
+    if extra > 0:
+        hsv = plt.get_cmap("hsv")
+        for idx in range(extra):
+            hue = (idx * 0.61803398875) % 1.0
+            colors.append(hsv(hue))
+
+    return {fuzzer: colors[idx] for idx, fuzzer in enumerate(ordered_fuzzers)}
+
+
+def build_non_fuzzer_color_map(
+    labels: Iterable[object], *, min_shade: float = 0.45, max_shade: float = 0.9
+) -> Dict[str, tuple]:
+    ordered_labels = sorted(
+        {str(label).strip() for label in labels if str(label).strip()}
+    )
+    shades = non_fuzzer_shades(
+        len(ordered_labels),
+        min_shade=min_shade,
+        max_shade=max_shade,
+    )
+    return {label: shades[idx] for idx, label in enumerate(ordered_labels)}

--- a/analysis/runner_metrics_report.py
+++ b/analysis/runner_metrics_report.py
@@ -16,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 from analysis import analyze
+from analysis.plot_palette import build_fuzzer_color_map
 
 
 REQUIRED_COLS = [
@@ -368,13 +369,25 @@ def plot_usage(
 
     out_png.parent.mkdir(parents=True, exist_ok=True)
     plt.figure(figsize=(9, 5))
+    ax = plt.gca()
+    fuzzer_colors = build_fuzzer_color_map(dist["fuzzer"].tolist())
     for fuzzer, group in dist.groupby("fuzzer", sort=True):
+        color = fuzzer_colors.get(str(fuzzer))
+        if color is None:
+            color = ax._get_lines.get_next_color()
         x = group["elapsed_hours"].to_numpy(dtype=float)
         p25 = group["p25"].to_numpy(dtype=float)
         p50 = group["p50"].to_numpy(dtype=float)
         p75 = group["p75"].to_numpy(dtype=float)
-        plt.fill_between(x, p25, p75, step="post", alpha=0.15)
-        plt.step(x, p50, where="post", linewidth=2.5, label=f"{fuzzer} (median)")
+        plt.fill_between(x, p25, p75, step="post", alpha=0.15, color=color)
+        plt.step(
+            x,
+            p50,
+            where="post",
+            linewidth=2.5,
+            label=f"{fuzzer} (median)",
+            color=color,
+        )
 
     plt.title(title)
     plt.xlabel("Elapsed time (hours)")

--- a/analysis/tests/test_benchmark_report.py
+++ b/analysis/tests/test_benchmark_report.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from analysis import benchmark_report
+from analysis import plot_palette
 
 
 def _make_metrics(fuzzer, final_values, runs=None, **kwargs):
@@ -33,17 +34,17 @@ def _make_metrics(fuzzer, final_values, runs=None, **kwargs):
 
 class BenchmarkReportTests(unittest.TestCase):
     def test_build_fuzzer_color_map_is_alphabetical_and_stable(self):
-        colors_a = benchmark_report.build_fuzzer_color_map(
+        colors_a = plot_palette.build_fuzzer_color_map(
             ["medusa", "foundry", "echidna", "medusa"]
         )
-        colors_b = benchmark_report.build_fuzzer_color_map(
+        colors_b = plot_palette.build_fuzzer_color_map(
             ["echidna", "medusa", "foundry"]
         )
         self.assertEqual(colors_a, colors_b)
         self.assertEqual(["echidna", "foundry", "medusa"], list(colors_a.keys()))
 
     def test_non_fuzzer_shades_uses_purples(self):
-        shades = benchmark_report.non_fuzzer_shades(3)
+        shades = plot_palette.non_fuzzer_shades(3)
         self.assertEqual(3, len(shades))
 
         expected = [
@@ -52,6 +53,12 @@ class BenchmarkReportTests(unittest.TestCase):
             plt.get_cmap("Purples")(0.9),
         ]
         self.assertEqual(expected, shades)
+
+    def test_build_non_fuzzer_color_map_is_alphabetical(self):
+        color_map = plot_palette.build_non_fuzzer_color_map(
+            ["medusa", "echidna", "foundry"]
+        )
+        self.assertEqual(["echidna", "foundry", "medusa"], list(color_map.keys()))
 
     def test_write_report_mentions_invariant_artifacts(self):
         metrics = [


### PR DESCRIPTION
## Summary
- make fuzzer color assignment deterministic and alphabetical via a shared color map
- reuse fuzzer colors across bugs-over-time, final distribution, and sample metric time-series charts
- move non-fuzzer dimensions to a dedicated purple palette (time-to-k and plateau/late-share)
- add regression tests for deterministic color mapping and purple shade generation

## Validation
- python3 -m unittest analysis.tests.test_benchmark_report
- python3 -m unittest analysis.tests.test_runner_metrics_report

Fixes #127