### PR TITLE
Support Foundry fail_on_assert failure events in analysis

### DIFF
--- a/analysis/analyze.py
+++ b/analysis/analyze.py
@@ -434,13 +434,18 @@ def normalize_foundry_failure_name(value: Any) -> Optional[str]:
     name = str(value).strip()
     if not name:
         return None
-    if ":" in name:
-        name = name.rsplit(":", 1)[-1].strip()
+    # Foundry fail_on_assert failures use "Contract:function"; keep only function
+    # name for cross-fuzzer normalization. Ignore unexpected multi-colon values.
+    if name.count(":") == 1:
+        contract_name, function_name = name.split(":", 1)
+        if contract_name and function_name:
+            name = function_name.strip()
     return name or None
 
 
 def extract_foundry_failure(payload: Dict[str, Any]) -> Tuple[Optional[str], Optional[float], Optional[str]]:
     ts_value = parse_optional_float(payload.get("timestamp"))
+    # We require timestamps to compute elapsed seconds in benchmark reports.
     if ts_value is None:
         return None, None, None
 
@@ -449,8 +454,10 @@ def extract_foundry_failure(payload: Dict[str, Any]) -> Tuple[Optional[str], Opt
     if invariant_name and payload_type == "invariant_failure":
         return invariant_name, ts_value, "foundry-invariant-failure"
 
-    # Fallback emitted by the local failure watcher.
-    if invariant_name and "failed" in payload:
+    # Backward-compat fallback for older watcher lines emitted before
+    # `type: invariant_failure` was added in `fuzzers/foundry/run.sh`.
+    failed_value = parse_optional_float(payload.get("failed"))
+    if invariant_name and failed_value is not None and failed_value > 0:
         return invariant_name, ts_value, "foundry-watcher-failure"
 
     # Newer Foundry failure event schema.

--- a/analysis/analyze.py
+++ b/analysis/analyze.py
@@ -428,6 +428,40 @@ def extract_bang_event(line: str) -> Optional[str]:
     return candidate
 
 
+def normalize_foundry_failure_name(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    name = str(value).strip()
+    if not name:
+        return None
+    if ":" in name:
+        name = name.rsplit(":", 1)[-1].strip()
+    return name or None
+
+
+def extract_foundry_failure(payload: Dict[str, Any]) -> Tuple[Optional[str], Optional[float], Optional[str]]:
+    ts_value = parse_optional_float(payload.get("timestamp"))
+    if ts_value is None:
+        return None, None, None
+
+    invariant_name = normalize_foundry_failure_name(payload.get("invariant"))
+    payload_type = str(payload.get("type") or "").strip()
+    if invariant_name and payload_type == "invariant_failure":
+        return invariant_name, ts_value, "foundry-invariant-failure"
+
+    # Fallback emitted by the local failure watcher.
+    if invariant_name and "failed" in payload:
+        return invariant_name, ts_value, "foundry-watcher-failure"
+
+    # Newer Foundry failure event schema.
+    if str(payload.get("event") or "").strip() == "failure":
+        target_name = normalize_foundry_failure_name(payload.get("target"))
+        if target_name:
+            return target_name, ts_value, "foundry-failure-event"
+
+    return None, ts_value, None
+
+
 def parse_foundry_log(
     path: Path, run_id: str, instance_id: str, fuzzer_label: str
 ) -> List[Event]:
@@ -443,35 +477,29 @@ def parse_foundry_log(
                 except json.JSONDecodeError:
                     payload = None
                 if payload is not None:
-                    invariant = payload.get("invariant")
-                    ts = payload.get("timestamp")
-                    if invariant and ts is not None:
-                        try:
-                            ts_value = float(ts)
-                        except (TypeError, ValueError):
-                            ts_value = None
-                        if ts_value is not None:
-                            if first_ts is None:
-                                # Foundry emits epoch timestamps; use the first seen
-                                # timestamp as the baseline so elapsed_seconds measures
-                                # time since the run began, not time since the first
-                                # failure.
-                                first_ts = ts_value
+                    event_name, ts_value, source = extract_foundry_failure(payload)
+                    if event_name and ts_value is not None and source:
+                        if first_ts is None:
+                            # Foundry emits epoch timestamps; use the first seen
+                            # timestamp as the baseline so elapsed_seconds measures
+                            # time since the run began, not time since the first
+                            # failure.
+                            first_ts = ts_value
 
-                            if payload.get("type") == "invariant_failure" and invariant not in seen:
-                                seen.add(invariant)
-                                events.append(
-                                    Event(
-                                        run_id=run_id,
-                                        instance_id=instance_id,
-                                        fuzzer=normalize_fuzzer(fuzzer_label),
-                                        fuzzer_label=fuzzer_label,
-                                        event=invariant,
-                                        elapsed_seconds=ts_value - first_ts,
-                                        source="foundry-invariant-failure",
-                                        log_path=str(path),
-                                    )
+                        if event_name not in seen:
+                            seen.add(event_name)
+                            events.append(
+                                Event(
+                                    run_id=run_id,
+                                    instance_id=instance_id,
+                                    fuzzer=normalize_fuzzer(fuzzer_label),
+                                    fuzzer_label=fuzzer_label,
+                                    event=event_name,
+                                    elapsed_seconds=ts_value - first_ts,
+                                    source=source,
+                                    log_path=str(path),
                                 )
+                            )
                     continue
     return events
 

--- a/analysis/analyze.py
+++ b/analysis/analyze.py
@@ -449,18 +449,6 @@ def extract_foundry_failure(payload: Dict[str, Any]) -> Tuple[Optional[str], Opt
     if ts_value is None:
         return None, None, None
 
-    invariant_name = normalize_foundry_failure_name(payload.get("invariant"))
-    payload_type = str(payload.get("type") or "").strip()
-    if invariant_name and payload_type == "invariant_failure":
-        return invariant_name, ts_value, "foundry-invariant-failure"
-
-    # Backward-compat fallback for older watcher lines emitted before
-    # `type: invariant_failure` was added in `fuzzers/foundry/run.sh`.
-    failed_value = parse_optional_float(payload.get("failed"))
-    if invariant_name and failed_value is not None and failed_value > 0:
-        return invariant_name, ts_value, "foundry-watcher-failure"
-
-    # Newer Foundry failure event schema.
     if str(payload.get("event") or "").strip() == "failure":
         target_name = normalize_foundry_failure_name(payload.get("target"))
         if target_name:
@@ -484,15 +472,15 @@ def parse_foundry_log(
                 except json.JSONDecodeError:
                     payload = None
                 if payload is not None:
+                    payload_ts = parse_optional_float(payload.get("timestamp"))
+                    if payload_ts is not None and first_ts is None:
+                        # Foundry emits epoch timestamps. Anchor elapsed time to the
+                        # first JSON event so failures are measured since the run
+                        # began, not since the first failure.
+                        first_ts = payload_ts
+
                     event_name, ts_value, source = extract_foundry_failure(payload)
                     if event_name and ts_value is not None and source:
-                        if first_ts is None:
-                            # Foundry emits epoch timestamps; use the first seen
-                            # timestamp as the baseline so elapsed_seconds measures
-                            # time since the run began, not time since the first
-                            # failure.
-                            first_ts = ts_value
-
                         if event_name not in seen:
                             seen.add(event_name)
                             events.append(
@@ -502,7 +490,7 @@ def parse_foundry_log(
                                     fuzzer=normalize_fuzzer(fuzzer_label),
                                     fuzzer_label=fuzzer_label,
                                     event=event_name,
-                                    elapsed_seconds=ts_value - first_ts,
+                                    elapsed_seconds=ts_value - (first_ts or ts_value),
                                     source=source,
                                     log_path=str(path),
                                 )

--- a/analysis/tests/test_analyze_foundry_parser.py
+++ b/analysis/tests/test_analyze_foundry_parser.py
@@ -29,15 +29,23 @@ class FoundryParserTests(unittest.TestCase):
         )
 
         events = analyze.parse_foundry_log(log_path, "run-1", "i-1", "foundry-git-test")
-        self.assertEqual([event.event for event in events], ["invariant_a", "invariant_b"])
+        self.assertEqual(
+            [event.event for event in events],
+            ["invariant_a", "invariant_b", "legacy_invariant"],
+        )
         self.assertEqual(
             [event.source for event in events],
-            ["foundry-invariant-failure", "foundry-invariant-failure"],
+            [
+                "foundry-invariant-failure",
+                "foundry-invariant-failure",
+                "foundry-watcher-failure",
+            ],
         )
-        self.assertAlmostEqual(events[0].elapsed_seconds, 1.0)
-        self.assertAlmostEqual(events[1].elapsed_seconds, 3.0)
+        self.assertAlmostEqual(events[0].elapsed_seconds, 0.0)
+        self.assertAlmostEqual(events[1].elapsed_seconds, 2.0)
+        self.assertAlmostEqual(events[2].elapsed_seconds, 3.0)
 
-    def test_ignores_legacy_foundry_records_without_type(self):
+    def test_parses_legacy_watcher_records_without_type(self):
         log_path = self.write_log(
             [
                 '{"timestamp":100,"invariant":"legacy_invariant","failed":1,"metrics":{"cumulative_edges_seen":1}}',
@@ -46,7 +54,31 @@ class FoundryParserTests(unittest.TestCase):
         )
 
         events = analyze.parse_foundry_log(log_path, "run-1", "i-1", "foundry-git-test")
-        self.assertEqual(events, [])
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event, "legacy_invariant")
+        self.assertEqual(events[0].source, "foundry-watcher-failure")
+
+    def test_parses_fail_on_assert_failure_events(self):
+        log_path = self.write_log(
+            [
+                '{"timestamp":200,"event":"failure","target":"CryticToFoundry:assert_canary_ASSERTION_CANARY","type":"assertion"}',
+                '{"timestamp":201,"event":"pulse","metrics":{"cumulative_edges_seen":4}}',
+                '{"timestamp":202,"event":"failure","target":"CryticToFoundry:assert_canary_ASSERTION_CANARY","type":"assertion"}',
+                '{"timestamp":203,"event":"failure","target":"CryticToFoundry:invariant_canary","type":"invariant"}',
+            ]
+        )
+
+        events = analyze.parse_foundry_log(log_path, "run-1", "i-1", "foundry-git-test")
+        self.assertEqual(
+            [event.event for event in events],
+            ["assert_canary_ASSERTION_CANARY", "invariant_canary"],
+        )
+        self.assertEqual(
+            [event.source for event in events],
+            ["foundry-failure-event", "foundry-failure-event"],
+        )
+        self.assertAlmostEqual(events[0].elapsed_seconds, 0.0)
+        self.assertAlmostEqual(events[1].elapsed_seconds, 3.0)
 
     def test_parses_throughput_from_json_cumulative_metrics(self):
         log_path = self.write_log(

--- a/analysis/tests/test_analyze_foundry_parser.py
+++ b/analysis/tests/test_analyze_foundry_parser.py
@@ -16,47 +16,38 @@ class FoundryParserTests(unittest.TestCase):
             tmp.close()
             raise
 
-    def test_parses_only_invariant_failure_records(self):
+    def test_parses_failure_event_records(self):
         log_path = self.write_log(
             [
-                '{"type":"invariant_metrics","timestamp":100,"invariant":"invariant_a","failed_current":0,"failed_total":0,"metrics":{"cumulative_edges_seen":1}}',
-                '{"type":"invariant_failure","timestamp":101,"invariant":"invariant_a","failed_total":1}',
-                '{"type":"invariant_failure","timestamp":102,"invariant":"invariant_a","failed_total":1}',
-                '{"type":"invariant_failure","timestamp":103,"invariant":"invariant_b","failed_total":2}',
-                '{"timestamp":104,"invariant":"legacy_invariant","failed":1,"metrics":{"cumulative_edges_seen":2}}',
-                "[FAIL: legacy] legacy_invariant()",
+                '{"timestamp":100,"event":"pulse","metrics":{"cumulative_edges_seen":1}}',
+                '{"timestamp":101,"event":"failure","target":"CryticToFoundry:invariant_a","type":"invariant"}',
+                '{"timestamp":102,"event":"failure","target":"CryticToFoundry:invariant_a","type":"invariant"}',
+                '{"timestamp":103,"event":"failure","target":"CryticToFoundry:invariant_b","type":"assertion"}',
+                '{"type":"invariant_failure","timestamp":104,"invariant":"legacy_invariant","failed_total":1}',
+                '{"timestamp":105,"invariant":"legacy_watcher","failed":1}',
             ]
         )
 
         events = analyze.parse_foundry_log(log_path, "run-1", "i-1", "foundry-git-test")
-        self.assertEqual(
-            [event.event for event in events],
-            ["invariant_a", "invariant_b", "legacy_invariant"],
-        )
+        self.assertEqual([event.event for event in events], ["invariant_a", "invariant_b"])
         self.assertEqual(
             [event.source for event in events],
-            [
-                "foundry-invariant-failure",
-                "foundry-invariant-failure",
-                "foundry-watcher-failure",
-            ],
+            ["foundry-failure-event", "foundry-failure-event"],
         )
-        self.assertAlmostEqual(events[0].elapsed_seconds, 0.0)
-        self.assertAlmostEqual(events[1].elapsed_seconds, 2.0)
-        self.assertAlmostEqual(events[2].elapsed_seconds, 3.0)
+        self.assertAlmostEqual(events[0].elapsed_seconds, 1.0)
+        self.assertAlmostEqual(events[1].elapsed_seconds, 3.0)
 
-    def test_parses_legacy_watcher_records_without_type(self):
+    def test_ignores_legacy_foundry_failure_records(self):
         log_path = self.write_log(
             [
+                '{"type":"invariant_failure","timestamp":100,"invariant":"legacy_invariant","failed_total":1}',
                 '{"timestamp":100,"invariant":"legacy_invariant","failed":1,"metrics":{"cumulative_edges_seen":1}}',
                 "[FAIL: legacy] legacy_invariant()",
             ]
         )
 
         events = analyze.parse_foundry_log(log_path, "run-1", "i-1", "foundry-git-test")
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0].event, "legacy_invariant")
-        self.assertEqual(events[0].source, "foundry-watcher-failure")
+        self.assertEqual(events, [])
 
     def test_parses_fail_on_assert_failure_events(self):
         log_path = self.write_log(

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -129,7 +129,7 @@ Optional controls include `EXCLUDE_FUZZERS`, `REPORT_BUDGET`, `REPORT_GRID_STEP_
 ### Event extraction semantics (`analysis/analyze.py`)
 
 - Parser is fuzzer-aware:
-  - Foundry: parse JSON lines and count events only from records with `type=invariant_failure`, using the first JSON `timestamp` as elapsed-time baseline.
+  - Foundry: parse JSON lines, count events only from records with `event=failure`, and use the first JSON `timestamp` as the elapsed-time baseline.
   - Medusa: parse elapsed markers and failed assertions/properties from textual logs.
   - Echidna variants: parse falsification markers from textual logs.
   - Unknown fuzzers: fall back to generic pattern parsing.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -35,12 +35,12 @@ export TF_VAR_timeout_hours=1
 export TF_VAR_instances_per_fuzzer=4
 export TF_VAR_fuzzers='["echidna","medusa","foundry"]'
 export TF_VAR_git_token_ssm_parameter_name="/scfuzzbench/recon/github_token"
-export TF_VAR_foundry_git_repo="https://github.com/aviggiano/foundry"
-export TF_VAR_foundry_git_ref="master"
+export TF_VAR_foundry_git_repo="https://github.com/0xalpharush/foundry"
+export TF_VAR_foundry_git_ref="fail_on_assert"
 ```
 
-For Foundry runs, use [aviggiano/foundry](https://github.com/aviggiano/foundry) with JSON `invariant_failure` emission enabled.
-Current analysis intentionally relies on these explicit failure events.
+For Foundry runs, prefer [0xalpharush/foundry](https://github.com/0xalpharush/foundry/tree/fail_on_assert) while this branch is being evaluated.
+Current analysis supports both legacy `invariant_failure` JSON and newer `event: failure` JSON events.
 
 ## Re-run A Benchmark
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,8 +39,8 @@ export TF_VAR_foundry_git_repo="https://github.com/0xalpharush/foundry"
 export TF_VAR_foundry_git_ref="fail_on_assert"
 ```
 
-For Foundry runs, prefer [0xalpharush/foundry](https://github.com/0xalpharush/foundry/tree/fail_on_assert) while this branch is being evaluated.
-Current analysis supports both legacy `invariant_failure` JSON and newer `event: failure` JSON events.
+For Foundry runs, use [0xalpharush/foundry](https://github.com/0xalpharush/foundry/tree/fail_on_assert).
+Current analysis expects the branch's `event: failure` JSON events.
 
 ## Re-run A Benchmark
 

--- a/fuzzers/foundry/run.sh
+++ b/fuzzers/foundry/run.sh
@@ -62,7 +62,9 @@ start_failure_watcher() {
           continue
         fi
         ts=$(date +%s)
-        printf '{"type":"invariant_failure","timestamp":%s,"invariant":"%s","failed":1}\n' "${ts}" "${invariant_name}" >> "${out_log}"
+        escaped_invariant="${invariant_name//\\/\\\\}"
+        escaped_invariant="${escaped_invariant//\"/\\\"}"
+        printf '{"type":"invariant_failure","timestamp":%d,"invariant":"%s","failed":1}\n' "${ts}" "${escaped_invariant}" >> "${out_log}"
       done < <(find "${failure_root}" -type f -print0 2>/dev/null)
     }
 

--- a/fuzzers/foundry/run.sh
+++ b/fuzzers/foundry/run.sh
@@ -62,7 +62,7 @@ start_failure_watcher() {
           continue
         fi
         ts=$(date +%s)
-        printf '{"timestamp":%s,"invariant":"%s","failed":1}\n' "${ts}" "${invariant_name}" >> "${out_log}"
+        printf '{"type":"invariant_failure","timestamp":%s,"invariant":"%s","failed":1}\n' "${ts}" "${invariant_name}" >> "${out_log}"
       done < <(find "${failure_root}" -type f -print0 2>/dev/null)
     }
 

--- a/fuzzers/foundry/run.sh
+++ b/fuzzers/foundry/run.sh
@@ -25,61 +25,6 @@ build_target
 
 repo_dir="${SCFUZZBENCH_WORKDIR}/target"
 log_file="${SCFUZZBENCH_LOG_DIR}/foundry.log"
-watcher_stop_file="${SCFUZZBENCH_LOG_DIR}/.foundry_failure_watcher.stop"
-
-start_failure_watcher() {
-  local root_dir=$1
-  local out_log=$2
-  local stop_file=$3
-  local failure_dir_rel=$4
-
-  (
-    declare -A seen_failure_files
-
-    seed_seen_failures() {
-      local failure_root="${root_dir}/${failure_dir_rel}"
-      if [[ ! -d "${failure_root}" ]]; then
-        return
-      fi
-      while IFS= read -r -d '' failure_file; do
-        seen_failure_files["${failure_file}"]=1
-      done < <(find "${failure_root}" -type f -print0 2>/dev/null)
-    }
-
-    emit_new_failures() {
-      local failure_root="${root_dir}/${failure_dir_rel}"
-      if [[ ! -d "${failure_root}" ]]; then
-        return
-      fi
-
-      while IFS= read -r -d '' failure_file; do
-        if [[ -n "${seen_failure_files[${failure_file}]:-}" ]]; then
-          continue
-        fi
-        seen_failure_files["${failure_file}"]=1
-        invariant_name=$(basename "${failure_file}")
-        if [[ -z "${invariant_name}" ]]; then
-          continue
-        fi
-        ts=$(date +%s)
-        escaped_invariant="${invariant_name//\\/\\\\}"
-        escaped_invariant="${escaped_invariant//\"/\\\"}"
-        printf '{"type":"invariant_failure","timestamp":%d,"invariant":"%s","failed":1}\n' "${ts}" "${escaped_invariant}" >> "${out_log}"
-      done < <(find "${failure_root}" -type f -print0 2>/dev/null)
-    }
-
-    # Ignore failures that existed before the campaign starts.
-    seed_seen_failures
-
-    while [[ ! -f "${stop_file}" ]]; do
-      emit_new_failures
-      sleep 5
-    done
-
-    # Final sweep after stop signal in case a failure landed just before exit.
-    emit_new_failures
-  ) &
-}
 
 extra_args=()
 if [[ -n "${FOUNDRY_TEST_ARGS:-}" ]]; then
@@ -104,17 +49,8 @@ fi
 
 set +e
 pushd "${repo_dir}" >/dev/null
-rm -f "${watcher_stop_file}"
-failure_persist_dir="${FOUNDRY_FAILURE_PERSIST_DIR:-cache/invariant}"
-start_failure_watcher "${repo_dir}" "${log_file}" "${watcher_stop_file}" "${failure_persist_dir}"
-failure_watcher_pid=$!
 run_with_timeout "${log_file}" forge test --mc CryticToFoundry "${extra_args[@]}"
 exit_code=$?
-touch "${watcher_stop_file}"
-if [[ -n "${failure_watcher_pid:-}" ]]; then
-  wait "${failure_watcher_pid}" || true
-fi
-rm -f "${watcher_stop_file}"
 popd >/dev/null
 set -e
 

--- a/skills/target-onboarding/SKILL.md
+++ b/skills/target-onboarding/SKILL.md
@@ -122,7 +122,8 @@ Required:
 5. do not add Foundry-only wrapper invariants (`invariant_assertion_failure_*`)
 6. do not add `_isAssertion`, `assertionFailures`, or overridden assert helpers in `CryticToFoundry.sol`
 7. `setUp()` must include handler routing (`targetContract`, multiple `targetSender` values)
-8. local review must confirm canonical identifier compatibility:
+8. include `invariant_noop() public returns (bool)` in `CryticToFoundry.sol` for assertion-focused smoke checks
+9. local review must confirm canonical identifier compatibility:
    - Echidna/Medusa report handler name (`targetFunctionName(...)`)
    - Foundry failure traces include handler name (`targetFunctionName_ASSERTION_*`)
    - canonical dedup key is `targetFunctionName`
@@ -317,6 +318,6 @@ Done means all are true:
 7. each fuzzer reports at least 2 canary bugs (assertion + global invariant) within 2 minutes
 8. exact `/start` JSON is provided
 9. PR URL is recorded in final report; include tracking issue URL only if one was explicitly requested
-10. all assertion failure reasons are constants in `Properties.sol` and all begin with `!!!`
+10. all assertion failure reasons are constants in `Properties.sol`; `!!!` prefix is recommended for consistent parser extraction
 11. every assertion handler `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>` has exactly one referenced `ASSERTION_*` constant
 12. assertion failures normalize to `targetFunctionName` across Echidna, Medusa, and Foundry

--- a/skills/target-onboarding/SKILL.md
+++ b/skills/target-onboarding/SKILL.md
@@ -47,17 +47,14 @@ Optional:
 8. Assertion reason centralization rule:
    - every assertion failure reason must be declared in `Properties.sol` as a `string constant`
    - no inline assertion reason literals in harness files (for example `CryticToFoundry.sol`)
-   - every assertion failure reason value must start with `!!!` (required by `_isAssertion` routing in `CryticToFoundry`)
+   - every assertion failure reason value should start with `!!!` (keeps assertion canary extraction consistent across fuzzers)
 9. Assertion naming normalization rule:
    - assertion handler functions must use `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>(...)`
    - `ASSERTION_CONSTANT_SUFFIX` must exactly match the referenced `ASSERTION_*` constant suffix
      - example: `ASSERTION_WITHDRAW_DOS` -> `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS(...)`
    - each assertion handler function must reference exactly one `ASSERTION_*` constant
    - if a property needs multiple checks (`gte/lte/eq/t/...`) in the same handler, all checks must use that same single `ASSERTION_*` constant
-   - Foundry wrappers must use `invariant_assertion_failure_targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>()`
-     - example: `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS` -> `invariant_assertion_failure_iSpoke_withdraw_ASSERTION_WITHDRAW_DOS()`
-   - wrapper suffix after `invariant_assertion_failure_` must exactly match the handler identifier (`targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`)
-   - canonical cross-fuzzer identifier for assertions is always `targetFunctionName` (strip `_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>` and strip Foundry wrapper prefix)
+   - canonical cross-fuzzer identifier for assertions is always `targetFunctionName` (strip `_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`)
      - example: `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS` -> `iSpoke_withdraw`
 10. Scope control rule:
    - prefer minimal, rename-first edits when applying naming normalization
@@ -91,9 +88,12 @@ Minimum files/directories to port:
 
 ### 3) Ensure benchmark-compatible config
 
-`foundry.toml` invariant section must include benchmark-compatible values:
+`foundry.toml` must include benchmark-compatible values:
 
 ```toml
+[profile.default]
+assertions_revert = false
+
 [invariant]
 runs = 500000000
 depth = 100
@@ -101,35 +101,35 @@ include_storage = true
 show_solidity = true
 show_metrics = true
 fail_on_revert = false
+fail_on_assert = true
 continuous_run = true
 corpus_dir = "corpus/foundry"
 ```
 
-### 4) Foundry assertion compatibility shim (`foundry-rs/foundry#13322`)
+### 4) Foundry assertion mode (preferred)
 
-Because assertion failures can be hidden in invariant output, enforce:
+Use Foundry assertion mode directly (no compatibility shim) when `fail_on_assert` support is available.
+
+Required:
 1. keep all assertion reason strings in `Properties.sol` as `string constant ASSERTION_* = "!!! ...";`
-2. assertion reason strings must be prefixed with `!!!` (including canaries), because `_isAssertion` uses this marker to classify failures
-3. maintain `mapping(string => bool) assertionFailures`
-4. override assert helpers (`gt/gte/lt/lte/eq/t`) to route assertion reasons through `_recordAssertion`
-5. include `_isAssertion(string memory reason)` and use it to distinguish assertion failures from global invariant checks
-6. name assertion handlers as `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>(...)`
+2. set `assertions_revert = false` under `[profile.default]` in `foundry.toml`
+3. set `fail_on_assert = true` under `[invariant]` in `foundry.toml`
+4. name assertion handlers as `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>(...)`
    - `ASSERTION_CONSTANT_SUFFIX` must exactly match the referenced `ASSERTION_*` constant suffix
    - examples: `iHub_mintFeeShares_ASSERTION_MINT_FEE_SHARES_PPS_CHANGE`, `iSpoke_withdraw_ASSERTION_WITHDRAW_DOS`, `assert_canary_ASSERTION_CANARY`
    - each assertion handler must reference exactly one `ASSERTION_*` constant
    - if multiple checks are required in one handler, reuse the same single `ASSERTION_*` constant across those checks
-7. add one wrapper `invariant_assertion_failure_targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>()` per assertion handler identifier
-8. wrappers must only check `assertionFailures[ASSERTION_*]` and must not trigger actions directly
-9. when a wrapper is tied to a handler identifier, wrapper suffix after `invariant_assertion_failure_` must exactly match that assertion handler identifier
-   - do not keep legacy multi-assert handlers; split/rename so every handler and wrapper pair maps to a single `ASSERTION_*`
-10. `setUp()` must include handler routing (`targetContract`, multiple `targetSender` values)
-11. do not pre-seed assertion failures in `setUp()` (no hardcoded `_recordAssertion(false, ...)`)
-12. local review must confirm canonical identifier compatibility:
-    - Echidna/Medusa report handler name (`targetFunctionName(...)`)
-    - Foundry reports wrapper name (`invariant_assertion_failure_targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`)
-    - canonical dedup key is `targetFunctionName`
+5. do not add Foundry-only wrapper invariants (`invariant_assertion_failure_*`)
+6. do not add `_isAssertion`, `assertionFailures`, or overridden assert helpers in `CryticToFoundry.sol`
+7. `setUp()` must include handler routing (`targetContract`, multiple `targetSender` values)
+8. local review must confirm canonical identifier compatibility:
+   - Echidna/Medusa report handler name (`targetFunctionName(...)`)
+   - Foundry failure traces include handler name (`targetFunctionName_ASSERTION_*`)
+   - canonical dedup key is `targetFunctionName`
 
-Reference pattern: https://github.com/foundry-rs/foundry/issues/13322
+Legacy fallback (only if pinning a Foundry without `fail_on_assert`):
+1. use the compatibility shim pattern from `foundry-rs/foundry#13322`
+2. keep wrapper invariants `invariant_assertion_failure_*` and assertion routing in `CryticToFoundry.sol`
 
 ### 5) Canary requirement for every target
 
@@ -137,7 +137,6 @@ Add these canaries to each target harness:
 1. Assertion canary:
    - helper/action function: `assert_canary_ASSERTION_CANARY(uint256 entropy)`
    - assertion reason string: `!!! canary assertion`
-   - Foundry wrapper invariant: `invariant_assertion_failure_assert_canary_ASSERTION_CANARY` (do not call `assert_canary_ASSERTION_CANARY` from inside this wrapper)
    - canonical assertion identifier: `assert_canary`
 2. Global invariant canary:
    - invariant function name must start with `invariant_`
@@ -164,34 +163,18 @@ function invariant_canary() public returns (bool) {
 
 ```solidity
 // CryticToFoundry.sol
-mapping(string => bool) internal assertionFailures;
-
-function _isAssertion(string memory reason) internal pure returns (bool) {
-    bytes memory b = bytes(reason);
-    return b.length >= 3 && b[0] == '!' && b[1] == '!' && b[2] == '!';
+function setUp() public override {
+    setup();
+    targetContract(address(this));
+    targetSender(address(0x10000));
+    targetSender(address(0x20000));
+    targetSender(address(0x30000));
 }
 
-function t(bool ok, string memory reason) internal virtual override(FoundryAsserts, Asserts) {
-    if (_isAssertion(reason)) {
-        _recordAssertion(ok, reason);
-        return;
-    }
-    super.t(ok, reason);
-}
-
-function _recordAssertion(bool ok, string memory reason) internal {
-    if (!ok) {
-        assertionFailures[reason] = true;
-    }
-}
-
-function invariant_assertion_failure_assert_canary_ASSERTION_CANARY() public returns (bool) {
-    assertTrue(
-        !assertionFailures[ASSERTION_CANARY],
-        ASSERTION_CANARY
-    );
-    return true;
-}
+// In fail_on_assert mode:
+// - do not add _isAssertion(...)
+// - do not add assertionFailures mapping
+// - do not add invariant_assertion_failure_* wrappers
 ```
 
 Both canaries are intentional failures used to verify:
@@ -243,10 +226,10 @@ Run all:
 6. Ensure `CryticToFoundry.sol` has no `test_*` repro/unit tests
 7. Canary smoke checks must fail within the smoke trial window:
    - `FOUNDRY_INVARIANT_CONTINUOUS_RUN=false forge test --match-contract CryticToFoundry --match-test invariant_canary -vv`
-   - `FOUNDRY_INVARIANT_CONTINUOUS_RUN=false forge test --match-contract CryticToFoundry --match-test 'invariant_assertion_failure_assert_canary_ASSERTION_CANARY' -vv`
+   - `FOUNDRY_INVARIANT_CONTINUOUS_RUN=false FOUNDRY_INVARIANT_RUNS=20000 FOUNDRY_INVARIANT_DEPTH=1 forge test --match-contract CryticToFoundry --match-test invariant_noop -vv`
 8. Acceptance gate: each fuzzer must report at least 2 bugs within 2 minutes:
    - one bug for `invariant_canary` (`Canary invariant`)
-   - one bug for the assertion canary (`!!! canary assertion` via `assert_canary_ASSERTION_CANARY` / `invariant_assertion_failure_assert_canary_ASSERTION_CANARY`), with canonical id `assert_canary`
+   - one bug for the assertion canary (`!!! canary assertion` via `assert_canary_ASSERTION_CANARY`), with canonical id `assert_canary`
 
 Suggested 2-minute commands:
 
@@ -295,8 +278,8 @@ Typical fields:
 7. `fuzzers`: `["echidna","medusa","foundry"]`
 8. optional `fuzzer_env_json` only when target-specific override is necessary
 9. optional Foundry source fields:
-   - `foundry_git_repo`: `https://github.com/aviggiano/foundry`
-   - `foundry_git_ref`: `master`
+   - `foundry_git_repo`: `https://github.com/0xalpharush/foundry`
+   - `foundry_git_ref`: `fail_on_assert`
 
 ## Common failures and fixes
 
@@ -307,19 +290,20 @@ Typical fields:
 3. Medusa: `insufficient gas for floor data gas cost`
    - raise `transactionGasLimit` and `blockGasLimit`
 4. Foundry failures not surfaced
-   - verify assertion reasons are constants in `Properties.sol` + `!!!` prefix + per-assertion invariants + overridden assert helpers
+   - verify `foundry.toml` sets `assertions_revert = false` and `[invariant].fail_on_assert = true`
+   - verify assertion reasons are constants in `Properties.sol` (recommended `!!!` prefix)
+   - if using fail-on-assert mode, remove compatibility shim code (`_isAssertion`, `assertionFailures`, `invariant_assertion_failure_*`)
 5. Foundry unrealistically fast/all bugs immediate
    - remove any `test_*` functions in `CryticToFoundry`
 6. Echidna returns 0 issues unexpectedly
    - enforce `testMode: "assertion"` with `prefix: "echidna_"` in `echidna.yaml`
    - enforce naming rule across inherited recon properties too: `invariant_*` must be no-arg, parameterized globals must be `global_*`
    - keep global checks out of `property_` and `crytic_`
-7. Broken-invariant overlap shows assertion bugs as Foundry-only (`invariant_assertion_failure_*`)
+7. Broken-invariant overlap shows assertion bugs as Foundry-only
    - ensure assertion handler is named `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`
    - ensure `ASSERTION_CONSTANT_SUFFIX` exactly matches the referenced `ASSERTION_*` constant suffix
-   - ensure Foundry wrapper is named `invariant_assertion_failure_targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`
-   - ensure wrapper suffix exactly matches handler identifier so canonical id remains `targetFunctionName`
    - ensure each handler references exactly one `ASSERTION_*` constant; split legacy multi-assert handlers when needed
+   - if using legacy shim mode, wrapper suffix must exactly match handler identifier
 
 ## Completion checklist
 
@@ -334,5 +318,5 @@ Done means all are true:
 8. exact `/start` JSON is provided
 9. PR URL is recorded in final report; include tracking issue URL only if one was explicitly requested
 10. all assertion failure reasons are constants in `Properties.sol` and all begin with `!!!`
-11. every assertion handler `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>` has exactly one referenced `ASSERTION_*` constant and a matching wrapper in `CryticToFoundry.sol`
+11. every assertion handler `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>` has exactly one referenced `ASSERTION_*` constant
 12. assertion failures normalize to `targetFunctionName` across Echidna, Medusa, and Foundry

--- a/skills/target-onboarding/SKILL.md
+++ b/skills/target-onboarding/SKILL.md
@@ -106,9 +106,9 @@ continuous_run = true
 corpus_dir = "corpus/foundry"
 ```
 
-### 4) Foundry assertion mode (preferred)
+### 4) Foundry assertion mode
 
-Use Foundry assertion mode directly (no compatibility shim) when `fail_on_assert` support is available.
+Use Foundry assertion mode directly. Compatibility-shim modes are not supported.
 
 Required:
 1. keep all assertion reason strings in `Properties.sol` as `string constant ASSERTION_* = "!!! ...";`
@@ -127,10 +127,6 @@ Required:
    - Echidna/Medusa report handler name (`targetFunctionName(...)`)
    - Foundry failure traces include handler name (`targetFunctionName_ASSERTION_*`)
    - canonical dedup key is `targetFunctionName`
-
-Legacy fallback (only if pinning a Foundry without `fail_on_assert`):
-1. use the compatibility shim pattern from `foundry-rs/foundry#13322`
-2. keep wrapper invariants `invariant_assertion_failure_*` and assertion routing in `CryticToFoundry.sol`
 
 ### 5) Canary requirement for every target
 
@@ -293,7 +289,7 @@ Typical fields:
 4. Foundry failures not surfaced
    - verify `foundry.toml` sets `assertions_revert = false` and `[invariant].fail_on_assert = true`
    - verify assertion reasons are constants in `Properties.sol` (recommended `!!!` prefix)
-   - if using fail-on-assert mode, remove compatibility shim code (`_isAssertion`, `assertionFailures`, `invariant_assertion_failure_*`)
+   - remove leftover compatibility shim code (`_isAssertion`, `assertionFailures`, `invariant_assertion_failure_*`)
 5. Foundry unrealistically fast/all bugs immediate
    - remove any `test_*` functions in `CryticToFoundry`
 6. Echidna returns 0 issues unexpectedly
@@ -304,7 +300,6 @@ Typical fields:
    - ensure assertion handler is named `targetFunctionName_ASSERTION_<ASSERTION_CONSTANT_SUFFIX>`
    - ensure `ASSERTION_CONSTANT_SUFFIX` exactly matches the referenced `ASSERTION_*` constant suffix
    - ensure each handler references exactly one `ASSERTION_*` constant; split legacy multi-assert handlers when needed
-   - if using legacy shim mode, wrapper suffix must exactly match handler identifier
 
 ## Completion checklist
 


### PR DESCRIPTION
## Summary
- extend Foundry log parsing to handle:
  - legacy `{"type":"invariant_failure","invariant":...}` format
  - watcher fallback format
  - new `fail_on_assert` format `{"event":"failure","target":...,"type":...}`
- normalize `target` keys like `Contract:function` to `function` for cross-fuzzer matching
- emit `type: "invariant_failure"` in watcher fallback logs for compatibility
- update operations docs and target-onboarding skill to prefer `0xalpharush/foundry` `fail_on_assert` and no-shim harness mode

## Validation
- `python3 -m py_compile analysis/analyze.py`
- parser unit-style checks:
  - legacy sample -> 1 event
  - watcher sample -> 1 event
  - new fail_on_assert sample -> 1 event
  - pulse-only sample -> 0 events
- real log check from timed Foundry run:
  - parsed events: `invariant_canary`, `assert_canary_ASSERTION_CANARY`

## Notes
- this keeps backward compatibility while enabling analysis of the new Foundry failure event schema.
