### PR TITLE
Fix run scripts when HOME is unset in cloud-init

### DIFF
--- a/fuzzers/echidna-symexec/run.sh
+++ b/fuzzers/echidna-symexec/run.sh
@@ -6,6 +6,9 @@ source "${SCFUZZBENCH_COMMON_SH:-/opt/scfuzzbench/common.sh}"
 register_shutdown_trap
 
 prepare_workspace
+if [[ -z "${HOME:-}" ]]; then
+  export HOME=/root
+fi
 export PATH="${HOME}/.foundry/bin:${PATH}"
 
 require_env ECHIDNA_VERSION BITWUZLA_VERSION

--- a/fuzzers/echidna/run.sh
+++ b/fuzzers/echidna/run.sh
@@ -6,6 +6,9 @@ source "${SCFUZZBENCH_COMMON_SH:-/opt/scfuzzbench/common.sh}"
 register_shutdown_trap
 
 prepare_workspace
+if [[ -z "${HOME:-}" ]]; then
+  export HOME=/root
+fi
 export PATH="${HOME}/.foundry/bin:${PATH}"
 
 require_env ECHIDNA_VERSION

--- a/fuzzers/foundry/run.sh
+++ b/fuzzers/foundry/run.sh
@@ -6,6 +6,9 @@ source "${SCFUZZBENCH_COMMON_SH:-/opt/scfuzzbench/common.sh}"
 register_shutdown_trap
 
 prepare_workspace
+if [[ -z "${HOME:-}" ]]; then
+  export HOME=/root
+fi
 export PATH="${HOME}/.foundry/bin:${PATH}"
 
 if [[ -n "${FOUNDRY_LABEL:-}" ]]; then

--- a/fuzzers/medusa/run.sh
+++ b/fuzzers/medusa/run.sh
@@ -6,6 +6,9 @@ source "${SCFUZZBENCH_COMMON_SH:-/opt/scfuzzbench/common.sh}"
 register_shutdown_trap
 
 prepare_workspace
+if [[ -z "${HOME:-}" ]]; then
+  export HOME=/root
+fi
 export PATH="${HOME}/.foundry/bin:${PATH}"
 
 require_env MEDUSA_VERSION


### PR DESCRIPTION
## Summary
- guard all fuzzer run scripts (`echidna`, `foundry`, `medusa`, `echidna-symexec`) against unset `HOME`
- default to `HOME=/root` only when `HOME` is missing
- keep local mode behavior unchanged when `HOME` is already set

## Why
Recent benchmark workers fail early with `HOME: unbound variable` at `run.sh:9` under cloud-init execution. In this path, scripts run with `set -u` and `HOME` is not guaranteed to be exported.

## Validation
- `bash -n fuzzers/echidna/run.sh`
- `bash -n fuzzers/foundry/run.sh`
- `bash -n fuzzers/medusa/run.sh`
- `bash -n fuzzers/echidna-symexec/run.sh`