### PR TITLE
fix: checkout fetched Foundry ref via FETCH_HEAD

### DIFF
--- a/fuzzers/_shared/common.sh
+++ b/fuzzers/_shared/common.sh
@@ -513,7 +513,8 @@ install_foundry() {
     git clone --depth 1 "${FOUNDRY_GIT_REPO}" "${tmp_dir}/foundry"
     if [[ -n "${FOUNDRY_GIT_REF:-}" ]]; then
       git -C "${tmp_dir}/foundry" fetch --depth 1 origin "${FOUNDRY_GIT_REF}"
-      git -C "${tmp_dir}/foundry" checkout "${FOUNDRY_GIT_REF}"
+      # `git fetch origin <ref>` updates FETCH_HEAD but does not always create a local branch.
+      git -C "${tmp_dir}/foundry" checkout --detach FETCH_HEAD
     fi
     local commit
     commit=$(git -C "${tmp_dir}/foundry" rev-parse --short HEAD)


### PR DESCRIPTION
## Summary
- fix Foundry source install for non-default refs (e.g. `fail_on_assert`)
- after `git fetch origin <ref>`, checkout `FETCH_HEAD` instead of `<ref>` name
- add inline note explaining why local branch checkout is unreliable in this fetch pattern

## Root cause
`git fetch --depth 1 origin fail_on_assert` updates `FETCH_HEAD` but does not create a local branch named `fail_on_assert`.
`git checkout fail_on_assert` then fails with:
`error: pathspec 'fail_on_assert' did not match any file(s) known to git`

That failure happens in `install_foundry`, before runner scripts register upload traps, so no `runs/<run_id>/<benchmark_uuid>/manifest.json` gets uploaded and the run never appears on scfuzzbench.com.

## Validation
- `bash -n fuzzers/_shared/common.sh`
- repro with aviggiano repo:
  - `git clone --depth 1 https://github.com/aviggiano/foundry ...`
  - `git fetch --depth 1 origin fail_on_assert`
  - `git checkout --detach FETCH_HEAD` ✅
- repro with 0xalpharush repo:
  - same sequence works ✅

Fixes the failure mode seen in benchmark requests like #150 / run `1775784021`.
