### PR TITLE
fix: disambiguate invariant overlap when a fuzzer has zero events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ report-events-to-cumulative: analysis-venv
 	$(ANALYSIS_PY) analysis/events_to_cumulative.py --events-csv $(EVENTS_CSV) --out-csv $(CUMULATIVE_CSV) --logs-dir $(ANALYSIS_LOGS_DIR) $(RUN_ID_ARG) $(EXCLUDE_ARG) $(RAW_LABELS_ARG)
 
 report-invariant-overlap: analysis-venv
-	$(ANALYSIS_PY) analysis/invariant_overlap_report.py --events-csv $(EVENTS_CSV) --out-md $(BROKEN_INVARIANTS_MD) --out-csv $(BROKEN_INVARIANTS_CSV) --out-png $(INVARIANT_OVERLAP_PNG) $(INVARIANT_BUDGET_ARG) --top-k $(INVARIANT_TOP_K)
+	$(ANALYSIS_PY) analysis/invariant_overlap_report.py --events-csv $(EVENTS_CSV) --logs-dir $(ANALYSIS_LOGS_DIR) --out-md $(BROKEN_INVARIANTS_MD) --out-csv $(BROKEN_INVARIANTS_CSV) --out-png $(INVARIANT_OVERLAP_PNG) $(INVARIANT_BUDGET_ARG) --top-k $(INVARIANT_TOP_K) $(RAW_LABELS_ARG)
 
 report-runner-metrics: analysis-venv
 	$(ANALYSIS_PY) analysis/runner_metrics_report.py --logs-dir $(ANALYSIS_LOGS_DIR) --out-summary-csv $(RUNNER_RESOURCE_SUMMARY_CSV) --out-timeseries-csv $(RUNNER_RESOURCE_TIMESERIES_CSV) --out-md $(RUNNER_RESOURCE_MD) --out-cpu-png $(CPU_USAGE_PNG) --out-memory-png $(MEMORY_USAGE_PNG) --bin-seconds $(RUNNER_METRICS_BIN_SECONDS) $(RUN_ID_ARG) $(RUNNER_BUDGET_ARG) $(RAW_LABELS_ARG)

--- a/analysis/invariant_overlap_report.py
+++ b/analysis/invariant_overlap_report.py
@@ -27,6 +27,7 @@ from analysis.plot_palette import (
     build_non_fuzzer_color_map,
     non_fuzzer_shades,
 )
+from analysis.events_to_cumulative import normalize_fuzzer, split_instance_label
 from analysis.trial_run import (
     MIN_BUDGET_HOURS,
     MIN_RUNS_PER_FUZZER,
@@ -115,7 +116,29 @@ def filter_budget(df: pd.DataFrame, budget_hours: Optional[float]) -> pd.DataFra
     return df[df["elapsed_seconds"] <= budget_seconds].reset_index(drop=True)
 
 
-def build_overlap(df: pd.DataFrame, *, total_events: int) -> OverlapResult:
+def list_fuzzers_from_logs(*, logs_dir: Path, raw_labels: bool) -> List[str]:
+    if not logs_dir.exists():
+        die(f"logs dir not found: {logs_dir}")
+    if not logs_dir.is_dir():
+        die(f"logs dir is not a directory: {logs_dir}")
+
+    fuzzers: set[str] = set()
+    for instance_dir in sorted([p for p in logs_dir.iterdir() if p.is_dir()]):
+        instance_id, fuzzer_label = split_instance_label(instance_dir.name)
+        if instance_id == "unknown":
+            continue
+        fuzzer = fuzzer_label if raw_labels else normalize_fuzzer(fuzzer_label)
+        if str(fuzzer).strip():
+            fuzzers.add(str(fuzzer).strip())
+    return sorted(fuzzers)
+
+
+def build_overlap(
+    df: pd.DataFrame,
+    *,
+    total_events: int,
+    expected_fuzzers: Optional[List[str]] = None,
+) -> OverlapResult:
     first_seen: Dict[str, Dict[str, float]] = defaultdict(dict)
     runs_hit: Dict[str, Dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
     set_membership: Dict[str, set[str]] = defaultdict(set)
@@ -131,6 +154,10 @@ def build_overlap(df: pd.DataFrame, *, total_events: int) -> OverlapResult:
         if prev is None or elapsed < prev:
             first_seen[invariant][fuzzer] = elapsed
         runs_hit[invariant][fuzzer].add(run_key)
+
+    if expected_fuzzers:
+        for fuzzer in expected_fuzzers:
+            set_membership.setdefault(str(fuzzer), set())
 
     fuzzers = sorted(set_membership.keys())
     set_sizes = {fuzzer: len(set_membership[fuzzer]) for fuzzer in fuzzers}
@@ -254,15 +281,23 @@ def write_md_report(
         lines.append(f"| {fuzzer} | {result.set_sizes.get(fuzzer, 0)} |")
     lines.append("")
 
+    active_fuzzers = [fuzzer for fuzzer in result.fuzzers if result.set_sizes.get(fuzzer, 0) > 0]
     all_combo = tuple(result.fuzzers)
+    active_combo = tuple(active_fuzzers)
     shared_all = (
-        len(result.intersections.get(all_combo, []))
-        if len(result.fuzzers) > 1
+        len(result.intersections.get(active_combo, []))
+        if len(active_fuzzers) > 1
         else len(next(iter(result.intersections.values())))
     )
     lines.append("## High-level overlap")
     lines.append("")
-    lines.append(f"- Shared by all fuzzers: **{shared_all}**")
+    lines.append(f"- Shared by all active fuzzers: **{shared_all}**")
+    if len(active_fuzzers) != len(result.fuzzers):
+        missing_fuzzers = [fuzzer for fuzzer in result.fuzzers if fuzzer not in active_fuzzers]
+        lines.append(
+            "- Fuzzers with no broken-invariant events: "
+            + f"`{', '.join(missing_fuzzers)}`"
+        )
     for fuzzer in result.fuzzers:
         count = len(result.intersections.get((fuzzer,), []))
         lines.append(f"- Exclusive to `{fuzzer}`: **{count}**")
@@ -280,11 +315,11 @@ def write_md_report(
         lines.append("</details>")
         lines.append("")
 
-    if len(result.fuzzers) > 1:
-        invariants = result.intersections.get(all_combo, [])
+    if len(active_fuzzers) > 1:
+        invariants = result.intersections.get(active_combo, [])
         lines.append("<details>")
         lines.append(
-            f"<summary>Shared by all fuzzers ({len(invariants)})</summary>"
+            f"<summary>Shared by all active fuzzers ({len(invariants)})</summary>"
         )
         lines.append("")
         render_invariant_list(lines, invariants, max_items=max_items_per_group)
@@ -293,7 +328,9 @@ def write_md_report(
 
     subset_entries: List[Tuple[Tuple[str, ...], List[str]]] = []
     for combo, invariants in result.intersections.items():
-        if len(combo) <= 1 or len(combo) == len(result.fuzzers):
+        if len(combo) <= 1:
+            continue
+        if len(active_fuzzers) > 1 and combo == active_combo:
             continue
         subset_entries.append((combo, invariants))
 
@@ -747,11 +784,25 @@ def parse_args() -> argparse.Namespace:
         description="Build broken-invariant overlap artifacts (CSV + Markdown + UpSet chart)."
     )
     parser.add_argument("--events-csv", type=Path, required=True)
+    parser.add_argument(
+        "--logs-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional prepared logs dir. If provided, include fuzzers that ran but "
+            "produced zero broken-invariant events."
+        ),
+    )
     parser.add_argument("--out-md", type=Path, required=True)
     parser.add_argument("--out-csv", type=Path, required=True)
     parser.add_argument("--out-png", type=Path, required=True)
     parser.add_argument("--budget-hours", type=float, default=None)
     parser.add_argument("--top-k", type=int, default=20)
+    parser.add_argument(
+        "--raw-labels",
+        action="store_true",
+        help="Use raw directory names as fuzzer labels instead of normalizing.",
+    )
     return parser.parse_args()
 
 
@@ -763,6 +814,11 @@ def main() -> int:
     events = load_events(args.events_csv)
     total_events = len(events)
     filtered = filter_budget(events, args.budget_hours)
+    expected_fuzzers = (
+        list_fuzzers_from_logs(logs_dir=args.logs_dir, raw_labels=args.raw_labels)
+        if args.logs_dir is not None
+        else None
+    )
 
     runs_per_fuzzer: List[int] = []
     if not filtered.empty:
@@ -772,7 +828,11 @@ def main() -> int:
             ).nunique()
             runs_per_fuzzer.append(int(run_keys))
 
-    result = build_overlap(filtered, total_events=total_events)
+    result = build_overlap(
+        filtered,
+        total_events=total_events,
+        expected_fuzzers=expected_fuzzers,
+    )
     write_csv_report(result, args.out_csv)
     write_md_report(
         result,

--- a/analysis/tests/test_invariant_overlap_report.py
+++ b/analysis/tests/test_invariant_overlap_report.py
@@ -138,6 +138,50 @@ class InvariantOverlapReportTests(unittest.TestCase):
                 ["iHub_mintFeeShares"],
             )
 
+    def test_report_includes_expected_fuzzers_with_zero_events(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "events.csv"
+            out_md = Path(tmp) / "broken_invariants.md"
+            csv_path.write_text(
+                "\n".join(
+                    [
+                        "run_id,instance_id,fuzzer,event,elapsed_seconds",
+                        "1,i-a,echidna,invariant_alpha(),10",
+                        "1,i-b,medusa,CryticTester.invariant_alpha(),12",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            events = overlap.load_events(csv_path)
+            result = overlap.build_overlap(
+                events,
+                total_events=len(events),
+                expected_fuzzers=["echidna", "foundry", "medusa"],
+            )
+            overlap.write_md_report(result, out_md, budget_hours=1.0, top_k=20)
+            report = out_md.read_text(encoding="utf-8")
+
+            self.assertEqual(result.set_sizes["foundry"], 0)
+            self.assertIn("| foundry | 0 |", report)
+            self.assertIn("Shared by all active fuzzers: **1**", report)
+            self.assertIn(
+                "Fuzzers with no broken-invariant events: `foundry`",
+                report,
+            )
+            self.assertIn("Shared by all active fuzzers (1)", report)
+
+    def test_list_fuzzers_from_logs_ignores_non_instance_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            logs_dir = Path(tmp)
+            (logs_dir / "data").mkdir()
+            (logs_dir / "i-aaa-foundry-git-test").mkdir()
+            (logs_dir / "i-bbb-echidna-v2").mkdir()
+
+            fuzzers = overlap.list_fuzzers_from_logs(logs_dir=logs_dir, raw_labels=False)
+            self.assertEqual(fuzzers, ["echidna", "foundry"])
+
     def test_detail_lines_without_limit_do_not_truncate(self):
         lines = overlap._detail_lines(
             entries=[("[foundry+medusa] foundry + medusa (2)", ["inv_a", "inv_b", "inv_c"])],


### PR DESCRIPTION
## Summary
- include fuzzers from `--logs-dir` in invariant-overlap artifacts, even when they have zero broken-invariant events
- update broken-invariants markdown wording from "all fuzzers" to "all active fuzzers"
- explicitly list fuzzers with no broken-invariant events in the high-level overlap section
- wire `report-invariant-overlap` to pass `--logs-dir` (and `--raw-labels`) so configured-but-empty fuzzers are represented

## Why
On runs where a fuzzer starts but emits no broken-invariant events (for example Foundry setup failure), the old report omitted that fuzzer and still said "shared by all fuzzers", which is misleading next to bug charts showing `0` for that fuzzer.

## Validation
- `/home/ubuntu/scfuzzbench/.venv-analysis/bin/python -m unittest analysis.tests.test_invariant_overlap_report`
- `/home/ubuntu/scfuzzbench/.venv-analysis/bin/python -m unittest analysis.tests.test_generate_docs_site`
- manual repro on run `1776020304/97398bfa6bfaa44239f06bed2deb1e70`: report now includes `foundry | 0` and "shared by all active fuzzers"