### PR TITLE
Handle legacy Foundry failure events for benchmark charts

### DIFF
--- a/analysis/analyze.py
+++ b/analysis/analyze.py
@@ -458,7 +458,15 @@ def parse_foundry_log(
                                 # failure.
                                 first_ts = ts_value
 
-                            if payload.get("type") == "invariant_failure" and invariant not in seen:
+                            payload_type = payload.get("type")
+                            is_invariant_failure = payload_type == "invariant_failure"
+                            failed_value = parse_optional_float(payload.get("failed"))
+                            is_legacy_failure = (
+                                payload_type is None
+                                and failed_value is not None
+                                and failed_value > 0.0
+                            )
+                            if (is_invariant_failure or is_legacy_failure) and invariant not in seen:
                                 seen.add(invariant)
                                 events.append(
                                     Event(
@@ -468,7 +476,11 @@ def parse_foundry_log(
                                         fuzzer_label=fuzzer_label,
                                         event=invariant,
                                         elapsed_seconds=ts_value - first_ts,
-                                        source="foundry-invariant-failure",
+                                        source=(
+                                            "foundry-invariant-failure"
+                                            if is_invariant_failure
+                                            else "foundry-legacy-failure"
+                                        ),
                                         log_path=str(path),
                                     )
                                 )

--- a/analysis/tests/test_analyze_foundry_parser.py
+++ b/analysis/tests/test_analyze_foundry_parser.py
@@ -16,7 +16,7 @@ class FoundryParserTests(unittest.TestCase):
             tmp.close()
             raise
 
-    def test_parses_only_invariant_failure_records(self):
+    def test_parses_invariant_failure_and_legacy_failed_records(self):
         log_path = self.write_log(
             [
                 '{"type":"invariant_metrics","timestamp":100,"invariant":"invariant_a","failed_current":0,"failed_total":0,"metrics":{"cumulative_edges_seen":1}}',
@@ -29,15 +29,23 @@ class FoundryParserTests(unittest.TestCase):
         )
 
         events = analyze.parse_foundry_log(log_path, "run-1", "i-1", "foundry-git-test")
-        self.assertEqual([event.event for event in events], ["invariant_a", "invariant_b"])
+        self.assertEqual(
+            [event.event for event in events],
+            ["invariant_a", "invariant_b", "legacy_invariant"],
+        )
         self.assertEqual(
             [event.source for event in events],
-            ["foundry-invariant-failure", "foundry-invariant-failure"],
+            [
+                "foundry-invariant-failure",
+                "foundry-invariant-failure",
+                "foundry-legacy-failure",
+            ],
         )
         self.assertAlmostEqual(events[0].elapsed_seconds, 1.0)
         self.assertAlmostEqual(events[1].elapsed_seconds, 3.0)
+        self.assertAlmostEqual(events[2].elapsed_seconds, 4.0)
 
-    def test_ignores_legacy_foundry_records_without_type(self):
+    def test_parses_legacy_foundry_failed_records_without_type(self):
         log_path = self.write_log(
             [
                 '{"timestamp":100,"invariant":"legacy_invariant","failed":1,"metrics":{"cumulative_edges_seen":1}}',
@@ -46,7 +54,10 @@ class FoundryParserTests(unittest.TestCase):
         )
 
         events = analyze.parse_foundry_log(log_path, "run-1", "i-1", "foundry-git-test")
-        self.assertEqual(events, [])
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event, "legacy_invariant")
+        self.assertEqual(events[0].source, "foundry-legacy-failure")
+        self.assertAlmostEqual(events[0].elapsed_seconds, 0.0)
 
     def test_parses_throughput_from_json_cumulative_metrics(self):
         log_path = self.write_log(

--- a/analysis/tests/test_generate_docs_site.py
+++ b/analysis/tests/test_generate_docs_site.py
@@ -25,6 +25,72 @@ class GenerateDocsSiteTests(unittest.TestCase):
         self.assertIn("#### Section", rewritten)
         self.assertIn("plain text", rewritten)
 
+    def test_first_markdown_image_returns_first_image(self):
+        module = load_generate_docs_site()
+        lines = [
+            "# Title",
+            "",
+            "![first alt](https://example.com/first.png)",
+            "![second alt](https://example.com/second.png)",
+        ]
+        image = module.first_markdown_image(lines)
+
+        self.assertEqual(("https://example.com/first.png", "first alt"), image)
+
+    def test_with_social_preview_head_uses_first_image(self):
+        module = load_generate_docs_site()
+        lines = [
+            "# Run `1`",
+            "",
+            "![Bugs Over Time](https://bucket.s3.us-east-1.amazonaws.com/analysis/abc/1/bugs_over_time.png)",
+            "![Another](https://bucket.s3.us-east-1.amazonaws.com/analysis/abc/1/other.png)",
+        ]
+
+        rendered = module.with_social_preview_head(
+            lines,
+            page_path="/runs/1/abc/",
+            title="scfuzzbench run 1 - org/repo",
+            description="Benchmark abc at 2026-03-07 00:00:00Z.",
+        )
+        joined = "\n".join(rendered)
+
+        self.assertTrue(rendered[0] == "---")
+        self.assertIn("property: og:image", joined)
+        self.assertIn(
+            'content: "https://bucket.s3.us-east-1.amazonaws.com/analysis/abc/1/bugs_over_time.png"',
+            joined,
+        )
+        self.assertIn('content: "scfuzzbench run 1 - org/repo"', joined)
+        self.assertIn('content: "Benchmark abc at 2026-03-07 00:00:00Z."', joined)
+        self.assertIn("name: twitter:title", joined)
+        self.assertIn("name: twitter:description", joined)
+        self.assertIn("name: twitter:image", joined)
+
+    def test_run_social_description_is_url_specific(self):
+        module = load_generate_docs_site()
+        run = module.Run(
+            run_id=1772801774,
+            benchmark_uuid="454f886c9668a94e8595de32219ce2b9",
+            manifest_key="runs/1772801774/454f886c9668a94e8595de32219ce2b9/manifest.json",
+            manifest={
+                "target_repo_url": "https://github.com/Recon-Fuzz/scfuzzbench",
+                "target_commit": "0123456789abcdef",
+                "fuzzer_keys": ["foundry", "echidna", "medusa"],
+            },
+            timeout_hours=24.0,
+            analyzed=True,
+            analysis_kind="analysis",
+            analysis_prefix="analysis/454f886c9668a94e8595de32219ce2b9/1772801774",
+        )
+
+        desc = module.run_social_description(run)
+
+        self.assertIn("Benchmark 454f886c9668a94e8595de32219ce2b9", desc)
+        self.assertIn("Timeout 24h", desc)
+        self.assertIn("Target Recon-Fuzz/scfuzzbench", desc)
+        self.assertIn("Commit 0123456789", desc)
+        self.assertIn("Fuzzers foundry, echidna, medusa", desc)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fuzzers/foundry/run.sh
+++ b/fuzzers/foundry/run.sh
@@ -62,7 +62,7 @@ start_failure_watcher() {
           continue
         fi
         ts=$(date +%s)
-        printf '{"timestamp":%s,"invariant":"%s","failed":1}\n' "${ts}" "${invariant_name}" >> "${out_log}"
+        printf '{"type":"invariant_failure","timestamp":%s,"invariant":"%s","failed":1}\n' "${ts}" "${invariant_name}" >> "${out_log}"
       done < <(find "${failure_root}" -type f -print0 2>/dev/null)
     }
 

--- a/scripts/generate_docs_site.py
+++ b/scripts/generate_docs_site.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import time
+from urllib.parse import urljoin
 from dataclasses import dataclass
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -24,7 +25,10 @@ from analysis.trial_run import (  # noqa: E402
 
 
 RUN_MANIFEST_RE = re.compile(r"^runs/([0-9]+)/([0-9a-f]{32})/manifest\.json$")
+MARKDOWN_IMAGE_RE = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<url>[^)\s]+)(?:\s+\"[^\"]*\")?\)")
 PRICING_API_REGION = "us-east-1"
+SITE_ORIGIN = "https://scfuzzbench.com"
+DEFAULT_SOCIAL_DESCRIPTION = "Benchmark suite for smart-contract fuzzers."
 DEFAULT_DOCS_EC2_PRICES_USD_PER_HOUR = {
     "c6a.4xlarge": 0.612,
     "c6a.8xlarge": 1.224,
@@ -125,6 +129,150 @@ def rewrite_headings(md: str, *, add: int) -> str:
         hashes, rest = m.group(1), m.group(2)
         out.append("#" * (len(hashes) + add) + rest)
     return "\n".join(out).rstrip() + "\n"
+
+
+def yaml_quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def truncate_meta_text(value: str, *, max_len: int) -> str:
+    text = " ".join(value.split())
+    if len(text) <= max_len:
+        return text
+    trimmed = text[: max_len - 3].rstrip(" .,;:-")
+    return f"{trimmed}..."
+
+
+def first_markdown_image(lines: list[str]) -> tuple[str, str] | None:
+    in_fence = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = MARKDOWN_IMAGE_RE.search(line)
+        if not m:
+            continue
+        url = m.group("url").strip()
+        if not url:
+            continue
+        alt = m.group("alt").strip() or "Preview image"
+        return url, alt
+    return None
+
+
+def first_heading_text(lines: list[str]) -> str:
+    for line in lines:
+        if not line.startswith("# "):
+            continue
+        return line[2:].strip().strip("`")
+    return ""
+
+
+def run_social_title(run_id: int, benchmark_uuid: str, target_repo_url: str) -> str:
+    target_label = compact_repo_label(target_repo_url)
+    if target_label:
+        return f"scfuzzbench run {run_id} - {target_label}"
+    return f"scfuzzbench run {run_id} - {short_uuid(benchmark_uuid)}"
+
+
+def run_social_description(run: Run) -> str:
+    m = run.manifest
+    parts: list[str] = [
+        f"Benchmark {run.benchmark_uuid}",
+        f"Date {utc_ts(run.run_id)}",
+        f"Timeout {run.timeout_hours:g}h",
+    ]
+
+    target_repo = str(m.get("target_repo_url", "")).strip()
+    if target_repo:
+        parts.append(f"Target {compact_repo_label(target_repo)}")
+
+    target_commit = str(m.get("target_commit", "")).strip()
+    if target_commit:
+        parts.append(f"Commit {shortish(target_commit, max_len=10)}")
+
+    fuzzer_keys = m.get("fuzzer_keys")
+    if isinstance(fuzzer_keys, list):
+        fuzzers = ", ".join(str(x).strip() for x in fuzzer_keys if str(x).strip())
+        if fuzzers:
+            parts.append(f"Fuzzers {fuzzers}")
+
+    return truncate_meta_text(". ".join(parts) + ".", max_len=240)
+
+
+def with_social_preview_head(
+    lines: list[str],
+    *,
+    page_path: str,
+    title: str | None = None,
+    description: str | None = None,
+) -> list[str]:
+    image = first_markdown_image(lines)
+    if image is None:
+        return lines
+
+    image_url, image_alt = image
+    page_url = urljoin(f"{SITE_ORIGIN}/", page_path.lstrip("/"))
+    absolute_image_url = urljoin(page_url, image_url)
+    meta_title = truncate_meta_text(
+        (title or "").strip() or first_heading_text(lines) or "scfuzzbench",
+        max_len=120,
+    )
+    meta_description = truncate_meta_text(
+        (description or "").strip() or DEFAULT_SOCIAL_DESCRIPTION,
+        max_len=240,
+    )
+
+    return [
+        "---",
+        "head:",
+        "  - - meta",
+        "    - name: description",
+        f"      content: {yaml_quote(meta_description)}",
+        "  - - meta",
+        "    - property: og:title",
+        f"      content: {yaml_quote(meta_title)}",
+        "  - - meta",
+        "    - property: og:description",
+        f"      content: {yaml_quote(meta_description)}",
+        "  - - meta",
+        "    - property: og:type",
+        "      content: website",
+        "  - - meta",
+        "    - property: og:url",
+        f"      content: {yaml_quote(page_url)}",
+        "  - - meta",
+        "    - property: og:image",
+        f"      content: {yaml_quote(absolute_image_url)}",
+        "  - - meta",
+        "    - property: og:image:secure_url",
+        f"      content: {yaml_quote(absolute_image_url)}",
+        "  - - meta",
+        "    - property: og:image:alt",
+        f"      content: {yaml_quote(image_alt)}",
+        "  - - meta",
+        "    - name: twitter:card",
+        "      content: summary_large_image",
+        "  - - meta",
+        "    - name: twitter:title",
+        f"      content: {yaml_quote(meta_title)}",
+        "  - - meta",
+        "    - name: twitter:description",
+        f"      content: {yaml_quote(meta_description)}",
+        "  - - meta",
+        "    - name: twitter:image",
+        f"      content: {yaml_quote(absolute_image_url)}",
+        "  - - meta",
+        "    - name: twitter:image:alt",
+        f"      content: {yaml_quote(image_alt)}",
+        "---",
+        "",
+        *lines,
+    ]
 
 
 def shortish(s: str, *, max_len: int = 10) -> str:
@@ -964,7 +1112,17 @@ def main() -> int:
             list_and_render(f"logs/{r.run_id}/{r.benchmark_uuid}/", "Raw logs (.zip)")
             list_and_render(f"corpus/{r.run_id}/{r.benchmark_uuid}/", "Raw corpus (.zip)")
 
-        write_text(run_dir / "index.md", "\n".join(lines).rstrip() + "\n")
+        page_lines = with_social_preview_head(
+            lines,
+            page_path=f"/runs/{r.run_id}/{r.benchmark_uuid}/",
+            title=run_social_title(
+                run_id=r.run_id,
+                benchmark_uuid=r.benchmark_uuid,
+                target_repo_url=str(m.get("target_repo_url", "")).strip(),
+            ),
+            description=run_social_description(r),
+        )
+        write_text(run_dir / "index.md", "\n".join(page_lines).rstrip() + "\n")
 
     return 0
 


### PR DESCRIPTION
## Summary
- parse legacy Foundry watcher records (`{"failed":1,...}`) as invariant failure events
- keep source attribution separate (`foundry-legacy-failure`) from native `invariant_failure` events
- update Foundry failure watcher emitter to write `type="invariant_failure"` for new runs

## Why
Recent runs can show broken invariants in Foundry output tables while benchmark event charts stay at 0 because legacy watcher records are not parsed as events.

## Validation
- `.venv-analysis/bin/python -m unittest analysis.tests.test_analyze_foundry_parser`
- manual parse check on legacy watcher-shaped logs now yields non-zero events